### PR TITLE
Support expressions inside strings and add unit tests

### DIFF
--- a/packages/plugin/tests/expression-parameter-interpolator.test.ts
+++ b/packages/plugin/tests/expression-parameter-interpolator.test.ts
@@ -37,6 +37,20 @@ describe('ExpressionParameterInterpolator', () => {
     expect(result).toBe('${input.missingKey}');
   });
 
+  it('interpolates expressions inside a string (placeholder)', () => {
+    const interpolator = new ExpressionParameterInterpolator();
+    const context = { workflow: { input: { name: 'World' } } };
+    const result = interpolator.interpolate('Hello ${input.name}', context);
+    expect(result).toBe('Hello World');
+  });
+
+  it('interpolates multiple placeholders in a string', () => {
+    const interpolator = new ExpressionParameterInterpolator();
+    const context = { workflow: { input: { firstName: 'John', lastName: 'Doe' } } };
+    const result = interpolator.interpolate('Hello ${input.firstName} ${input.lastName}', context);
+    expect(result).toBe('Hello John Doe');
+  });
+
   it('loads configuration correctly', async () => {
     const context = {
       getConfigProvider: jest.fn().mockReturnValue({

--- a/workflow-samples/sample-workflow-input.json
+++ b/workflow-samples/sample-workflow-input.json
@@ -5,7 +5,7 @@
       "name": "task1",
       "handler": "http",
       "parameters": {
-        "url": "${input.name}",
+        "url": "https://jsonplaceholder.typicode.com/${input.name}/1",
         "method": "GET"
       }
     }


### PR DESCRIPTION
Before we only supported the whole value as an expression like **"${input.name}"**, but now the library can interpolate the expression inside a string like **"Hello ${input.name}"** -> **"Hello world"**