### PR TITLE
Fix missing README on cli and core npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to npm on Release
 
-on: workflow_dispatch
+on:
+  release:
+    types: [created]
 
 jobs:
   build-and-test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14281,6 +14281,7 @@
         "@types/node": "^20.11.5",
         "@types/treeify": "^1.0.3",
         "@types/winston": "^2.4.4",
+        "copyfiles": "^2.4.1",
         "esbuild": "^0.19.11",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules npm run jest -- --coverage",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules npm run jest",
     "jest": "jest",
-    "prepublishOnly": "npm run build && npm run test"
+    "prepublishOnly": "npm run build && npm run test && copyfiles -f ../../README.md ./dist"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
     "@types/node": "^20.11.5",
     "@types/treeify": "^1.0.3",
     "@types/winston": "^2.4.4",
+    "copyfiles": "^2.4.1",
     "esbuild": "^0.19.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules npm run jest -- --coverage",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules npm run jest",
     "jest": "jest",
-    "prepublishOnly": "npm run build && npm run test"
+    "prepublishOnly": "npm run build && npm run test && copyfiles -f ../../README.md ./dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just copy the readme from the root to the publishing package.
Also turn on the auto-publish npm package on release, hope it works :|