### PR TITLE
Be able to abort a running workflow

### DIFF
--- a/packages/core/src/error/interrupt-invoke.error.ts
+++ b/packages/core/src/error/interrupt-invoke.error.ts
@@ -1,5 +1,5 @@
 /**
- * Error thrown when an interrupt is invoked while invoking a chain of plugins.
+ * Error thrown when an interrupt is invoked while invoking a chain of plugins or tasks.
  */
 export class InterruptInvokeError extends Error {
   /** The name of the error. */

--- a/packages/core/src/model/execution-session.ts
+++ b/packages/core/src/model/execution-session.ts
@@ -18,6 +18,9 @@ export interface ExecutionSession {
    */
   readonly systemTasks: Record<string, TaskHandler>;
 
+  /** The signal to abort the workflow execution. */
+  readonly signal: AbortSignal;
+
   /**
    * Sets tasks for a parent task.
    * @param parentTask - The parent task.

--- a/packages/core/src/model/runner.ts
+++ b/packages/core/src/model/runner.ts
@@ -33,4 +33,9 @@ export interface Runner {
    * @returns A promise that resolves to the workflow.
    */
   run(workflowDef: WorkflowDef | Workflow, input?: any): Promise<Workflow | undefined>;
+
+  /**
+   * Aborts the running workflow.
+   */
+  abort(): void;
 }

--- a/packages/core/src/model/workflow/workflow.ts
+++ b/packages/core/src/model/workflow/workflow.ts
@@ -16,4 +16,4 @@ export interface Workflow extends Container {
 }
 
 /** Type representing the possible statuses of a workflow. */
-export type WorkflowStatus = 'open' | 'executing' | 'error' | 'completed';
+export type WorkflowStatus = 'open' | 'executing' | 'error' | 'completed' | 'cancelled';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { ObjectType } from './types';
-import { InvalidParameterError } from './error';
+import { InterruptInvokeError, InvalidParameterError } from './error';
 import type Joi from 'joi';
 import { Container, Plugin, Task, TaskDef, TaskStatus, WorkflowTaskDefs, WorkflowTasks } from '@src/model';
 
@@ -36,10 +36,28 @@ export function getEntryPointDir(): string {
 /**
  * Delays execution for a specified number of milliseconds.
  * @param {number} ms - The number of milliseconds to delay.
+ * @param abortSignal - The abort signal to use for aborting the delay.
  * @returns {Promise<void>} A promise that resolves after the specified delay.
  */
-export function delayMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+export function delayMs(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    let id: NodeJS.Timeout;
+    const cancel = () => {
+      clearTimeout(id);
+      resolve();
+    };
+
+    id = setTimeout(() => {
+      if (abortSignal) {
+        abortSignal.removeEventListener('abort', cancel);
+      }
+      resolve();
+    }, ms);
+
+    if (abortSignal) {
+      abortSignal.addEventListener('abort', cancel, { once: true });
+    }
+  });
 }
 
 /**
@@ -192,4 +210,32 @@ export function countTasks(tasks: WorkflowTasks | undefined, deep: boolean = tru
 export function isTerminatedStatus(status: TaskStatus): boolean {
   const terminatedStatuses: TaskStatus[] = ['completed', 'error', 'cancelled'];
   return terminatedStatuses.includes(status);
+}
+
+export function wrapPromiseWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    // If the signal is already aborted, reject the promise immediately
+    if (signal.aborted) {
+      return reject(new InterruptInvokeError('Aborted'));
+    }
+
+    // Attach an abort event listener to reject the promise if aborted
+    const onAbort = () => {
+      reject(new InterruptInvokeError('Aborted'));
+    };
+
+    signal.addEventListener('abort', onAbort);
+
+    // Resolve or reject the promise as normal
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -41,6 +41,11 @@ export function getEntryPointDir(): string {
  */
 export function delayMs(ms: number, abortSignal?: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
+    if (abortSignal?.aborted) {
+      resolve();
+      return;
+    }
+
     let id: NodeJS.Timeout;
     const cancel = () => {
       clearTimeout(id);

--- a/packages/engine/src/runner/default-execution-session.ts
+++ b/packages/engine/src/runner/default-execution-session.ts
@@ -30,6 +30,7 @@ export class DefaultExecutionSession implements ExecutionSession {
     public readonly tasksFactory: TasksFactory,
     public readonly runner: Runner,
     public readonly systemTasks: Record<string, TaskHandler>,
+    public readonly signal: AbortSignal,
     private readonly context: AppContext,
     private readonly idGenerator: IdGenerator,
   ) {

--- a/packages/engine/src/system-task/delay.ts
+++ b/packages/engine/src/system-task/delay.ts
@@ -19,11 +19,11 @@ export class DelayTaskHandler implements TaskHandler {
   description: string = 'Delays the execution of the workflow for a specified amount of time';
   parameters: Joi.Description = Schema.describe();
 
-  async handle({ task, context }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, context, session }: TaskHandlerInput): Promise<TaskHandlerOutput> {
     const { time, data } = validateParameters(task.parameters, Schema);
     const delayMillis = typeof time === 'string' ? ms(time) : time;
     context.getLogger().verbose(`Delaying execution for ${delayMillis} milliseconds`);
-    await delayMs(delayMillis);
+    await delayMs(delayMillis, session.signal);
     return data;
   }
 }

--- a/packages/engine/src/system-task/http.ts
+++ b/packages/engine/src/system-task/http.ts
@@ -102,7 +102,7 @@ export class HttpTaskHandler implements TaskHandler {
    * @returns {Promise<TaskHandlerOutput>} The output of the task.
    * @throws {Error} If the HTTP request fails.
    */
-  async handle({ task }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, session }: TaskHandlerInput): Promise<TaskHandlerOutput> {
     const value = validateParameters(task.parameters, Schema);
     const url = new URL(value.url);
     if (value.params) {
@@ -117,7 +117,7 @@ export class HttpTaskHandler implements TaskHandler {
       method: value.method,
       headers: value.headers,
       body: value.body,
-      signal: value.timeoutMs ? AbortSignal.timeout(value.timeoutMs) : undefined,
+      signal: value.timeoutMs ? AbortSignal.any([AbortSignal.timeout(value.timeoutMs), session.signal]) : undefined,
     });
 
     if (!response.ok) {

--- a/packages/engine/src/system-task/run-workflow.ts
+++ b/packages/engine/src/system-task/run-workflow.ts
@@ -1,4 +1,4 @@
-import { RunnerOptions, TaskHandler, TaskHandlerInput, validateParameters } from '@letrun/core';
+import { RunnerOptions, TaskHandler, TaskHandlerInput, validateParameters, wrapPromiseWithAbort } from '@letrun/core';
 import Joi from 'joi';
 import fs from 'fs';
 
@@ -63,7 +63,7 @@ export class RunWorkflowTaskHandler implements TaskHandler {
     }
 
     context.getLogger().info(`Running workflow: ${workflowToRun?.name}`);
-    const ranWorkflow = await session.runner.run(workflowToRun, input);
+    const ranWorkflow = await wrapPromiseWithAbort(session.runner.run(workflowToRun, input), session.signal);
     if (ranWorkflow) {
       if (ranWorkflow.status === 'completed') {
         context.getLogger().info(`Workflow ${ranWorkflow.name} completed successfully`);

--- a/packages/engine/tests/runner/default-execution-session.test.ts
+++ b/packages/engine/tests/runner/default-execution-session.test.ts
@@ -20,8 +20,10 @@ describe('DefaultExecutionSession', () => {
   let mockSystemTasks: Record<string, jest.Mocked<TaskHandler>>;
   let mockWorkflow: jest.Mocked<Workflow>;
   let mockIdGenerator: jest.Mocked<IdGenerator>;
+  let abortController: AbortController;
 
   beforeEach(() => {
+    abortController = new AbortController();
     mockContext = {
       getLogger: jest.fn().mockReturnValue({
         warn: jest.fn(),
@@ -51,6 +53,7 @@ describe('DefaultExecutionSession', () => {
       mockTasksFactory,
       mockRunner,
       mockSystemTasks,
+      abortController.signal,
       mockContext,
       mockIdGenerator,
     );

--- a/packages/engine/tests/system-task/delay.test.ts
+++ b/packages/engine/tests/system-task/delay.test.ts
@@ -7,9 +7,15 @@ const jest = import.meta.jest;
 describe('DelayTaskHandler', () => {
   let delayTaskHandler: DelayTaskHandler;
   let mockContext: jest.Mocked<any>;
+  let abortController: AbortController;
+  let mockSession: jest.Mocked<any>;
 
   beforeEach(() => {
     delayTaskHandler = new DelayTaskHandler();
+    abortController = new AbortController();
+    mockSession = {
+      signal: abortController.signal,
+    };
     mockContext = {
       getLogger: jest.fn().mockReturnValue({
         verbose: jest.fn(),
@@ -22,6 +28,7 @@ describe('DelayTaskHandler', () => {
     const taskInput: TaskHandlerInput = {
       task: { parameters: { time: '1s' } },
       context: mockContext,
+      session: mockSession,
     } as any;
 
     await delayTaskHandler.handle(taskInput);
@@ -33,6 +40,7 @@ describe('DelayTaskHandler', () => {
     const taskInput: TaskHandlerInput = {
       task: { parameters: { time: '1s', data: 'testData' } },
       context: mockContext,
+      session: mockSession,
     } as any;
 
     const result: TaskHandlerOutput = await delayTaskHandler.handle(taskInput);
@@ -44,10 +52,12 @@ describe('DelayTaskHandler', () => {
     const taskInputString: TaskHandlerInput = {
       task: { parameters: { time: '2s' } },
       context: mockContext,
+      session: mockSession,
     } as any;
     const taskInputNumber: TaskHandlerInput = {
       task: { parameters: { time: 2000 } },
       context: mockContext,
+      session: mockSession,
     } as any;
 
     await delayTaskHandler.handle(taskInputString);

--- a/packages/engine/tests/system-task/delay.test.ts
+++ b/packages/engine/tests/system-task/delay.test.ts
@@ -58,4 +58,24 @@ describe('DelayTaskHandler', () => {
 
     delayMsSpy.mockRestore();
   });
+
+  it('aborts while delaying', async () => {
+    const abortController = new AbortController();
+    const taskInput: TaskHandlerInput = {
+      task: { parameters: { time: '5s' } },
+      context: mockContext,
+      session: { signal: abortController.signal },
+    } as any;
+
+    // cancel after 1s
+    global.setTimeout(() => {
+      abortController.abort();
+    }, 1000);
+
+    const startTime = Date.now();
+    await delayTaskHandler.handle(taskInput);
+    const endTime = Date.now();
+
+    expect(endTime - startTime).toBeLessThan(2000);
+  });
 });

--- a/packages/engine/tests/system-task/http.test.ts
+++ b/packages/engine/tests/system-task/http.test.ts
@@ -6,9 +6,15 @@ const jest = import.meta.jest;
 describe('HttpTaskHandler', () => {
   let handler: HttpTaskHandler;
   let mockTask: jest.Mocked<Task>;
+  let abortController: AbortController;
+  let mockSession: jest.Mocked<any>;
 
   beforeEach(() => {
     handler = new HttpTaskHandler();
+    abortController = new AbortController();
+    mockSession = {
+      signal: abortController.signal,
+    };
     mockTask = {
       parameters: {},
     } as unknown as jest.Mocked<Task>;
@@ -50,7 +56,12 @@ describe('HttpTaskHandler', () => {
 
   it('handles request timeout', async () => {
     mockTask.parameters = { url: 'https://api.example.com/data', method: 'GET', timeoutMs: 1 };
-    const input: TaskHandlerInput = { task: mockTask, context: {}, session: {}, workflow: {} as any } as any;
+    const input: TaskHandlerInput = {
+      task: mockTask,
+      context: {},
+      session: mockSession,
+      workflow: {} as any,
+    } as any;
     global.fetch = jest
       .fn()
       .mockImplementation(() => new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 2)));
@@ -81,12 +92,20 @@ describe('HttpTaskHandler', () => {
   it('aborts while requesting', async () => {
     const abortController = new AbortController();
     mockTask.parameters = { url: 'https://api.example.com/data', method: 'GET' };
-    const input: TaskHandlerInput = { task: mockTask, context: {}, session: { signal: abortController.signal }, workflow: {} as any } as any;
+    const input: TaskHandlerInput = {
+      task: mockTask,
+      context: {},
+      session: { signal: abortController.signal },
+      workflow: {} as any,
+    } as any;
 
-    global.fetch = jest.fn().mockImplementation(() => new Promise((_, reject) => {
-      abortController.abort();
-      reject(new Error('The operation was aborted.'));
-    }));
+    global.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          abortController.abort();
+          reject(new Error('The operation was aborted.'));
+        }),
+    );
 
     await expect(handler.handle(input)).rejects.toThrow('The operation was aborted.');
     expect(global.fetch).toHaveBeenCalled();

--- a/packages/engine/tests/system-task/run-workflow.test.ts
+++ b/packages/engine/tests/system-task/run-workflow.test.ts
@@ -81,4 +81,35 @@ describe('RunWorkflowTaskHandler', () => {
     jest.spyOn(fs.promises, 'readFile').mockRejectedValue(new Error('File read error'));
     await expect(handler.handle(input)).rejects.toThrow('File read error');
   });
+
+  it('aborts while running sub-workflow', async () => {
+    const abortController = new AbortController();
+    mockTask.parameters = { workflow: { name: 'testWorkflow' }, input: { key: 'value' } };
+    const input: TaskHandlerInput = {
+      task: mockTask,
+      context: mockContext,
+      session: { ...mockSession, signal: abortController.signal },
+      workflow: {} as any,
+    };
+
+    let runTimeout: NodeJS.Timeout | undefined;
+    mockSession.runner.run.mockImplementation(() => {
+      return new Promise((resolve) => {
+        runTimeout = global.setTimeout(() => {
+          resolve('result');
+        }, 2000);
+      });
+    });
+
+    global.setTimeout(() => {
+      abortController.abort();
+    }, 1000);
+
+    const startTime = Date.now();
+    await expect(handler.handle(input)).rejects.toThrow('Aborted');
+    expect(Date.now() - startTime).toBeLessThan(2000);
+    expect(mockSession.runner.run).toHaveBeenCalled();
+
+    clearTimeout(runTimeout);
+  });
 });

--- a/packages/engine/tests/system-task/run-workflow.test.ts
+++ b/packages/engine/tests/system-task/run-workflow.test.ts
@@ -9,8 +9,10 @@ describe('RunWorkflowTaskHandler', () => {
   let mockContext: jest.Mocked<any>;
   let mockSession: jest.Mocked<any>;
   let mockTask: jest.Mocked<Task>;
+  let abortController: AbortController;
 
   beforeEach(() => {
+    abortController = new AbortController();
     handler = new RunWorkflowTaskHandler();
     mockContext = {
       getLogger: jest.fn().mockReturnValue({
@@ -22,6 +24,7 @@ describe('RunWorkflowTaskHandler', () => {
       runner: {
         run: jest.fn(),
       },
+      signal: abortController.signal,
     };
     mockTask = {
       parameters: {},

--- a/packages/plugin/src/default-workflow-runner.ts
+++ b/packages/plugin/src/default-workflow-runner.ts
@@ -57,6 +57,10 @@ export default class DefaultWorkflowRunner extends AbstractPlugin implements Wor
 
     const { workflow } = input;
 
+    if (input.session.signal.aborted) {
+      return lastResult;
+    }
+
     // there may be some parent tasks that are in executing status,
     // we need to close them whenever all their children are completed or one of them failed
     await this.closeParentTasks(workflow);

--- a/packages/plugin/tests/default-workflow-runner.test.ts
+++ b/packages/plugin/tests/default-workflow-runner.test.ts
@@ -11,11 +11,16 @@ import {
   WorkflowRunner,
   WorkflowRunnerInput,
 } from '@letrun/core';
-import { Subject } from "rxjs";
+import { Subject } from 'rxjs';
 
 const jest = import.meta.jest;
 
 describe('DefaultWorkflowRunner', () => {
+  let abortController: AbortController;
+  beforeEach(() => {
+    abortController = new AbortController();
+  });
+
   it('loads context and logger correctly', async () => {
     const context = {
       getLogger: jest.fn(() => ({
@@ -263,6 +268,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -314,6 +320,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -360,6 +367,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -425,6 +433,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -478,6 +487,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -525,6 +535,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);
@@ -582,6 +593,7 @@ describe('DefaultWorkflowRunner', () => {
     } as unknown as AppContext;
     const session = {
       resolveParameter: jest.fn().mockResolvedValue({}),
+      signal: abortController.signal,
     } as unknown as ExecutionSession;
     const runner = new DefaultWorkflowRunner() as WorkflowRunner;
     jest.spyOn(runner, 'getContext').mockReturnValue(context);


### PR DESCRIPTION
Call `runner.abort()` to abort a running workflow by this runner immediately. The workflow status will be cancelled after it has been aborted.