### PR TITLE
Be able to retry tasks

### DIFF
--- a/docs/task/task-structure.md
+++ b/docs/task/task-structure.md
@@ -10,6 +10,11 @@ A task should have the following structure:
 - `parameters`: An object that provides input and configuration for the task. This field supports interpolation, which means you can reference the output of other tasks or the workflow input. This field is optional.
 - `ignoreError`: Whether to ignore errors during task execution and let other tasks continue running. This is optional.
 - `tasks`: An array of tasks to be executed (will be executed orderly) or an object of tasks (will be executed concurrently). This is optional.
+- `retryCount`: The number of times to retry the task if it fails (defaults to 3). This is optional.
+- `retryStrategy`: The strategy to use for retrying the task (defaults to 'fixed'). This is optional.
+- `retryDelaySeconds`: The delay between retries in seconds (defaults to 3 seconds). This is optional.
+
+> For retrying configuration, they are inherited from the parent container (workflow or task) if not defined.
 
 There are some special fields that depend on the handler:
 

--- a/docs/workflow/workflow-structure.md
+++ b/docs/workflow/workflow-structure.md
@@ -7,6 +7,9 @@ A Workflow Definition should have the following structure:
 - `name`: The name of the workflow. This is required.
 - `tasks`: An array of tasks to be executed (will be executed orderly) or an object of tasks (will be executed concurrently). This is required.
 - `input`: An object that provides input for the workflow. Other tasks can access this input using the `${input}` expression. You can pass the input when executing the workflow. This is optional.
+- `retryCount`: The number of times to retry the task if it fails (defaults to 3). This is optional.
+- `retryStrategy`: The strategy to use for retrying the task (defaults to 'fixed'). This is optional.
+- `retryDelaySeconds`: The delay between retries in seconds (defaults to 3 seconds). This is optional.
 
 This is an example of a workflow file:
 

--- a/packages/core/src/model/index.ts
+++ b/packages/core/src/model/index.ts
@@ -9,3 +9,5 @@ export * from './plugin-manager';
 export * from './runner';
 export * from './task-handler';
 export * from './tasks-factory';
+export * from './retryable';
+export * from './retry-config';

--- a/packages/core/src/model/retry-config.ts
+++ b/packages/core/src/model/retry-config.ts
@@ -1,0 +1,24 @@
+export interface RetryConfig {
+  /**
+   * Number of retries to attempt when a Task is marked as failure.
+   *
+   * Defaults to 3 with maximum allowed capped at 10.
+   */
+  retryCount?: number;
+
+  /**
+   * Mechanism for the retries.
+   *
+   * Defaults to 'fixed'.
+   */
+  retryStrategy?: RetryStrategy;
+
+  /**
+   * Time to wait before retries in seconds.
+   *
+   * Defaults to 3 seconds.
+   */
+  retryDelaySeconds?: number;
+}
+
+export type RetryStrategy = 'fixed' | 'exponential_backoff' | 'linear_backoff' | string;

--- a/packages/core/src/model/retryable.ts
+++ b/packages/core/src/model/retryable.ts
@@ -1,0 +1,3 @@
+export interface Retryable {
+  retries?: number;
+}

--- a/packages/core/src/model/workflow/container-def.ts
+++ b/packages/core/src/model/workflow/container-def.ts
@@ -1,9 +1,10 @@
 import { WorkflowTaskDefs } from './workflow-task-defs';
+import { RetryConfig } from '../retry-config';
 
 /**
  * Interface representing a container definition.
  */
-export interface ContainerDef {
+export interface ContainerDef extends RetryConfig {
   /** Name of the container definition, useful for distinguishing and referencing for interpolating values
    * from either the {@link ContainerDef.input} or {@link TaskDef.parameters}.
    * */

--- a/packages/core/src/model/workflow/task.ts
+++ b/packages/core/src/model/workflow/task.ts
@@ -2,13 +2,14 @@ import { ObjectType } from '@src/types';
 import { WorkflowTasks } from './workflow-tasks';
 import { Container } from './container';
 import { TaskDef } from './task-def';
+import { Retryable } from '../retryable';
 
 /**
  * Interface representing a task, generated based on the {@link TaskDef} automatically.
  * Holds the runtime information of the task.
  * Extends the Container interface.
  */
-export interface Task extends Container {
+export interface Task extends Container, Retryable {
   /** Runtime name of the task. It may be the same as the {@link TaskDef.name} in most cases.
    * In looping cases, it may depend on the iteration.
    * */

--- a/packages/core/src/model/workflow/workflow.ts
+++ b/packages/core/src/model/workflow/workflow.ts
@@ -1,12 +1,13 @@
-import { ObjectType } from '@src/types';
+import { RetryConfig } from '../retry-config';
 import { Container } from './container';
+import { ObjectType } from '../../types';
 
 /**
  * Interface representing a workflow, generated based on the {@link WorkflowDef} automatically.
  * Holds the runtime information of the workflow.
  * Extends the Container interface.
  */
-export interface Workflow extends Container {
+export interface Workflow extends Container, RetryConfig {
   /** The status of the workflow. */
   status: WorkflowStatus;
   /** Optional variables associated with the workflow. All tasks inside this workflow can access and change variables whenever they want. */

--- a/packages/core/src/plugin/command-plugin.ts
+++ b/packages/core/src/plugin/command-plugin.ts
@@ -4,5 +4,7 @@ import { Plugin } from '@src/model';
 export const COMMAND_PLUGIN = 'command';
 
 export interface CommandPlugin extends Plugin {
+  readonly type: typeof COMMAND_PLUGIN;
+
   register(program: Command): void;
 }

--- a/packages/core/src/plugin/id-generator.ts
+++ b/packages/core/src/plugin/id-generator.ts
@@ -7,6 +7,8 @@ export const ID_GENERATOR_PLUGIN = 'id-generator';
  * Extends the Plugin interface.
  */
 export interface IdGenerator extends Plugin {
+  readonly type: typeof ID_GENERATOR_PLUGIN;
+
   /**
    * Generates a unique ID.
    * @param parentId - Optional parent ID to prefix the generated ID.

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -10,3 +10,4 @@ export * from './input-parameter';
 export * from './id-generator';
 export * from './abstract-plugin';
 export * from './common';
+export * from './retry-plugin';

--- a/packages/core/src/plugin/input-parameter.ts
+++ b/packages/core/src/plugin/input-parameter.ts
@@ -11,5 +11,7 @@ export const INPUT_PARAMETER_PLUGIN = 'input-parameter';
  * Extends the Plugin interface.
  */
 export interface InputParameter extends Plugin {
+  readonly type: typeof INPUT_PARAMETER_PLUGIN;
+
   read<T = any>(rawInput: string): Promise<T | null>;
 }

--- a/packages/core/src/plugin/log-transport-plugin.ts
+++ b/packages/core/src/plugin/log-transport-plugin.ts
@@ -7,5 +7,7 @@ export const LOG_TRANSPORT_PLUGIN = 'log-transport';
  * Interface representing a Winston log transport plugin.
  */
 export interface LogTransportPlugin extends Plugin {
+  readonly type: typeof LOG_TRANSPORT_PLUGIN;
+
   getTransport(): Transport;
 }

--- a/packages/core/src/plugin/logger-plugin.ts
+++ b/packages/core/src/plugin/logger-plugin.ts
@@ -10,6 +10,8 @@ export type PreHookFn = (level: string, message: string, ...args: any[]) => bool
  * Interface representing a Logger plugin.
  */
 export interface LoggerPlugin extends Plugin {
+  readonly type: typeof LOGGER_PLUGIN;
+
   getLogger(): Logger;
 
   /**

--- a/packages/core/src/plugin/parameter-interpolator.ts
+++ b/packages/core/src/plugin/parameter-interpolator.ts
@@ -6,6 +6,8 @@ export const PARAMETER_INTERPOLATOR_PLUGIN = 'parameter-interpolator';
  * Interface representing a Parameter Interpolator plugin.
  */
 export interface ParameterInterpolator extends Plugin {
+  readonly type: typeof PARAMETER_INTERPOLATOR_PLUGIN;
+
   /**
    * Interpolates a given value within a specified context.
    * @param {string} value - The value to interpolate.

--- a/packages/core/src/plugin/persistence.ts
+++ b/packages/core/src/plugin/persistence.ts
@@ -39,6 +39,8 @@ export interface PersistenceUnit {
  * Interface representing a Persistence plugin.
  */
 export interface Persistence extends Plugin {
+  readonly type: typeof PERSISTENCE_PLUGIN;
+
   /**
    * Retrieves a persistence unit by name.
    * @param {string} name - The name of the persistence unit.

--- a/packages/core/src/plugin/retry-plugin.ts
+++ b/packages/core/src/plugin/retry-plugin.ts
@@ -1,0 +1,17 @@
+import { Plugin, Retryable, RetryConfig } from '../model';
+
+export const RETRY_PLUGIN = 'retry';
+
+export interface RetryInput<T> {
+  retryable: Retryable;
+  config: RetryConfig;
+  shouldRetryFn?: (err: Error) => boolean;
+  doJob: () => Promise<T>;
+  signal?: AbortSignal;
+}
+
+export interface RetryPlugin extends Plugin {
+  readonly type: typeof RETRY_PLUGIN;
+
+  retry<T = any>(input: RetryInput<T>): Promise<T>;
+}

--- a/packages/core/src/plugin/script-engine.ts
+++ b/packages/core/src/plugin/script-engine.ts
@@ -7,6 +7,8 @@ export const SCRIPT_ENGINE_PLUGIN = 'script-engine';
  * Interface representing a script engine plugin which support evaluate script in specific language.
  */
 export interface ScriptEngine extends Plugin {
+  readonly type: typeof SCRIPT_ENGINE_PLUGIN;
+
   run(script: string, context: ObjectType): Promise<any>;
 
   /**

--- a/packages/core/src/plugin/task-invoker.ts
+++ b/packages/core/src/plugin/task-invoker.ts
@@ -3,5 +3,7 @@ import { Plugin, TaskHandlerInput, TaskHandlerOutput } from '@src/model';
 export const TASK_INVOKER_PLUGIN = 'task-invoker';
 
 export interface TaskInvoker extends Plugin {
+  readonly type: typeof TASK_INVOKER_PLUGIN;
+
   invoke(input: TaskHandlerInput): Promise<TaskHandlerOutput>;
 }

--- a/packages/core/src/plugin/workflow-runner.ts
+++ b/packages/core/src/plugin/workflow-runner.ts
@@ -21,4 +21,6 @@ export interface WorkflowRunnerInput {
 /**
  * Interface representing a Workflow Runner plugin.
  */
-export interface WorkflowRunner extends ExecutablePlugin<WorkflowRunnerInput> {}
+export interface WorkflowRunner extends ExecutablePlugin<WorkflowRunnerInput> {
+  readonly type: typeof WORKFLOW_RUNNER_PLUGIN;
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -244,3 +244,11 @@ export function wrapPromiseWithAbort<T>(promise: Promise<T>, signal: AbortSignal
     );
   });
 }
+
+export function isValueDefined<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null;
+}
+
+export function isDefined(value: any): boolean {
+  return value !== undefined && value !== null;
+}

--- a/packages/engine/src/runner/default-runner.ts
+++ b/packages/engine/src/runner/default-runner.ts
@@ -201,6 +201,9 @@ export class DefaultRunner implements Runner {
       name: workflowDef.name,
       status: 'open',
       tasks: tasksFactory.createTasks(taskDefs),
+      retryCount: workflowDef.retryCount,
+      retryStrategy: workflowDef.retryStrategy,
+      retryDelaySeconds: workflowDef.retryDelaySeconds,
     };
   }
 }

--- a/packages/plugin/src/default-id-generator.ts
+++ b/packages/plugin/src/default-id-generator.ts
@@ -4,8 +4,8 @@ import { AbstractPlugin, AppContext, BUILTIN_PLUGIN_PRIORITY, ID_GENERATOR_PLUGI
  * Class responsible for generating unique IDs.
  */
 export default class DefaultIdGenerator extends AbstractPlugin implements IdGenerator {
-  name = 'default';
-  type = ID_GENERATOR_PLUGIN;
+  readonly name = 'default';
+  readonly type = ID_GENERATOR_PLUGIN;
   readonly priority = BUILTIN_PLUGIN_PRIORITY;
 
   private idSeparator = '/';

--- a/packages/plugin/src/default-retry-plugin.ts
+++ b/packages/plugin/src/default-retry-plugin.ts
@@ -1,0 +1,76 @@
+import {
+  AbstractPlugin,
+  AppContext,
+  delayMs,
+  InterruptInvokeError,
+  RETRY_PLUGIN,
+  RetryConfig,
+  RetryInput,
+  RetryPlugin,
+} from '@letrun/core';
+
+const DEFAULT_RETRY_DELAY_SECONDS = 3;
+const DEFAULT_RETRY_COUNT = 3;
+
+export default class DefaultRetryPlugin extends AbstractPlugin implements RetryPlugin {
+  readonly type = RETRY_PLUGIN;
+  readonly name = 'default';
+
+  private backoffRate = 1.5;
+
+  protected async doLoad(context: AppContext): Promise<void> {
+    await super.doLoad(context);
+    await this.injectConfig();
+  }
+
+  async retry<T = any>({ doJob, shouldRetryFn, retryable, config, signal }: RetryInput<T>): Promise<T> {
+    if (signal?.aborted) {
+      throw new InterruptInvokeError('Aborted');
+    }
+
+    let attemptNumber = 0;
+    const maxAttempts = Math.max(config.retryCount ?? DEFAULT_RETRY_COUNT, 0);
+
+    while (attemptNumber < maxAttempts) {
+      try {
+        return await doJob();
+      } catch (error) {
+        attemptNumber++;
+        retryable.retries = attemptNumber;
+
+        if (attemptNumber >= maxAttempts) {
+          throw error; // Rethrow the error if max attempts reached
+        }
+
+        if (shouldRetryFn && !shouldRetryFn(error as Error)) {
+          throw error; // Rethrow the error if the caller doesn't want to retry on this error
+        }
+
+        const delayMilliseconds = this.getRetryDelay(attemptNumber, config);
+        await delayMs(delayMilliseconds, signal);
+
+        if (signal?.aborted) {
+          throw new InterruptInvokeError('Aborted');
+        }
+      }
+    }
+
+    return doJob();
+  }
+
+  private getRetryDelay(
+    attemptNumber: number,
+    { retryDelaySeconds = DEFAULT_RETRY_DELAY_SECONDS, retryStrategy }: RetryConfig,
+  ): number {
+    switch (retryStrategy ?? 'fixed') {
+      case 'fixed':
+        return retryDelaySeconds * 1000;
+      case 'exponential_backoff':
+        return retryDelaySeconds * Math.pow(2, attemptNumber) * 1000;
+      case 'linear_backoff':
+        return retryDelaySeconds * this.backoffRate * attemptNumber * 1000;
+      default:
+        throw new Error(`Unsupported retry strategy: ${retryStrategy}`);
+    }
+  }
+}

--- a/packages/plugin/src/default-workflow-runner.ts
+++ b/packages/plugin/src/default-workflow-runner.ts
@@ -2,16 +2,22 @@ import {
   AbstractPlugin,
   BUILTIN_PLUGIN_PRIORITY,
   childHasStatus,
+  ConfigNotFoundError,
   countTasks,
   ExecutablePlugin,
   ExecutionSession,
   getTasksByStatus,
   IllegalStateError,
   InterruptInvokeError,
+  InvalidParameterError,
+  isDefined,
   isTerminatedStatus,
   POST_RUN_TASK_PLUGIN,
   PRE_RUN_TASK_PLUGIN,
   RerunError,
+  RETRY_PLUGIN,
+  RetryConfig,
+  RetryPlugin,
   scanAllTasks,
   Task,
   TASK_INVOKER_PLUGIN,
@@ -23,6 +29,14 @@ import {
   WorkflowRunnerInput,
   WorkflowTasks,
 } from '@letrun/core';
+
+const SYSTEM_ERRORS = [
+  InterruptInvokeError.name,
+  RerunError.name,
+  InvalidParameterError.name,
+  IllegalStateError.name,
+  ConfigNotFoundError.name,
+];
 
 export default class DefaultWorkflowRunner extends AbstractPlugin implements WorkflowRunner {
   readonly name = 'default';
@@ -258,9 +272,15 @@ export default class DefaultWorkflowRunner extends AbstractPlugin implements Wor
     let error: any;
 
     try {
-      output = await this.getContext()
-        .getPluginManager()
-        .callPluginMethod<TaskInvoker>(TASK_INVOKER_PLUGIN, 'invoke', input);
+      const pluginManager = this.getContext().getPluginManager();
+      const retryPlugin = await pluginManager.getOne<RetryPlugin>(RETRY_PLUGIN);
+      output = await retryPlugin.retry({
+        retryable: task,
+        config: this.lookupRetryConfig(task, input.session),
+        shouldRetryFn: (err) => !SYSTEM_ERRORS.includes(err.name),
+        doJob: () => pluginManager.callPluginMethod<TaskInvoker>(TASK_INVOKER_PLUGIN, 'invoke', input),
+        signal: input.session.signal,
+      });
       this.context?.getLogger()?.info(`Task ${taskName} is completed successfully.`);
     } catch (e: any) {
       if (e.name === RerunError.name) {
@@ -327,6 +347,40 @@ export default class DefaultWorkflowRunner extends AbstractPlugin implements Wor
     }
 
     return input.task.output;
+  }
+
+  private lookupRetryConfig(task: Task, session: ExecutionSession): RetryConfig {
+    const config: RetryConfig = {};
+
+    let currentTask: Task | undefined = task;
+
+    while (currentTask) {
+      const taskDef = currentTask.taskDef;
+      if (!taskDef) {
+        break;
+      }
+
+      // Check if the current task has any of the retry config properties
+      if (isDefined(taskDef.retryCount) && !isDefined(config.retryCount)) {
+        config.retryCount = taskDef.retryCount;
+      }
+      if (isDefined(taskDef.retryStrategy) && !isDefined(config.retryStrategy)) {
+        config.retryStrategy = taskDef.retryStrategy;
+      }
+      if (isDefined(taskDef.retryDelaySeconds) && !isDefined(config.retryDelaySeconds)) {
+        config.retryDelaySeconds = taskDef.retryDelaySeconds;
+      }
+
+      // If all properties are found, break the loop
+      if (isDefined(config.retryCount) && isDefined(config.retryStrategy) && isDefined(config.retryDelaySeconds)) {
+        break;
+      }
+
+      // Get the parent task and continue the search
+      currentTask = session.getParentTask(currentTask);
+    }
+
+    return config;
   }
 
   private completeTask(task: Task) {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -9,6 +9,7 @@ import DefaultIdGenerator from './default-id-generator';
 import WinstonLoggerPlugin from './winston-logger-plugin';
 import JavascriptEngine from './javascript-engine';
 import PythonEngine from './python-engine';
+import DefaultRetryPlugin from './default-retry-plugin';
 
 const DEFAULT_PLUGINS: Plugin[] = [
   new ConsoleLogger(),
@@ -21,6 +22,7 @@ const DEFAULT_PLUGINS: Plugin[] = [
   new WinstonLoggerPlugin(),
   new JavascriptEngine(),
   new PythonEngine(),
+  new DefaultRetryPlugin(),
 ];
 
 export class DefaultPluginLoader implements PluginLoader {

--- a/packages/plugin/src/winston-logger-plugin.ts
+++ b/packages/plugin/src/winston-logger-plugin.ts
@@ -93,8 +93,8 @@ class DefaultLogger implements Logger, Pick<LoggerPlugin, 'hook'> {
 }
 
 export default class WinstonLoggerPlugin extends AbstractPlugin implements LoggerPlugin {
-  name = 'winston-logger';
-  type = LOGGER_PLUGIN;
+  readonly name = 'winston-logger';
+  readonly type = LOGGER_PLUGIN;
   readonly priority = BUILTIN_PLUGIN_PRIORITY;
 
   private winstonLogger = createLogger({

--- a/packages/plugin/tests/default-retry-plugin.test.ts
+++ b/packages/plugin/tests/default-retry-plugin.test.ts
@@ -1,0 +1,193 @@
+import DefaultRetryPlugin from '@src/default-retry-plugin';
+import { ExecutionSession, InterruptInvokeError, RetryConfig, Task, WorkflowRunner } from '@letrun/core';
+import DefaultWorkflowRunner from '@src/default-workflow-runner';
+
+const jest = import.meta.jest;
+
+describe('DefaultRetryPlugin', () => {
+  let retryPlugin: DefaultRetryPlugin;
+
+  beforeEach(() => {
+    retryPlugin = new DefaultRetryPlugin();
+  });
+
+  it('retries the job until it succeeds', async () => {
+    const doJob = jest.fn().mockRejectedValueOnce(new Error('Job failed')).mockResolvedValueOnce('Job succeeded');
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const signal = new AbortController().signal;
+
+    const result = await retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal });
+
+    expect(result).toBe('Job succeeded');
+    expect(doJob).toHaveBeenCalledTimes(2);
+    expect(retryable.retries).toBe(1);
+  });
+
+  it('throws error if max retry attempts are reached', async () => {
+    const doJob = jest.fn().mockRejectedValue(new Error('Job failed'));
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const signal = new AbortController().signal;
+
+    await expect(retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal })).rejects.toThrow('Job failed');
+    expect(doJob).toHaveBeenCalledTimes(3);
+    expect(retryable.retries).toBe(3);
+  });
+
+  it('throws error if shouldRetryFn returns false', async () => {
+    const doJob = jest.fn().mockRejectedValue(new Error('Job failed'));
+    const shouldRetryFn = jest.fn().mockReturnValue(false);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const signal = new AbortController().signal;
+
+    await expect(retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal })).rejects.toThrow('Job failed');
+    expect(doJob).toHaveBeenCalledTimes(1);
+    expect(retryable.retries).toBe(1);
+  });
+
+  it('throws InterruptInvokeError if signal is aborted', async () => {
+    const doJob = jest.fn().mockRejectedValue(new Error('Job failed'));
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    setTimeout(() => abortController.abort(), 500);
+
+    await expect(retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal })).rejects.toThrow(
+      InterruptInvokeError,
+    );
+    expect(doJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws InterruptInvokeError if signal is aborted before retry method is called', async () => {
+    const doJob = jest.fn().mockRejectedValue(new Error('Job failed'));
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    abortController.abort(); // Abort the signal before calling retry
+
+    await expect(retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal })).rejects.toThrow(
+      InterruptInvokeError,
+    );
+    expect(doJob).not.toHaveBeenCalled();
+  });
+
+  it('calculates correct delay for fixed strategy', async () => {
+    const doJob = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Job failed'))
+      .mockRejectedValueOnce(new Error('Job failed again'))
+      .mockResolvedValueOnce('Job succeeded');
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'fixed' };
+    const signal = new AbortController().signal;
+
+    const result = await retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal });
+
+    expect(result).toBe('Job succeeded');
+    expect(doJob).toHaveBeenCalledTimes(3);
+    expect(retryable.retries).toBe(2);
+
+    const delayMilliseconds = retryPlugin['getRetryDelay'](0, config);
+    expect(delayMilliseconds).toBe(1000); // 1 * 1000
+
+    const delayMilliseconds2 = retryPlugin['getRetryDelay'](1, config);
+    expect(delayMilliseconds2).toBe(1000); // 1 * 1000
+  });
+
+  it('calculates correct delay for exponential_backoff strategy', async () => {
+    const doJob = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Job failed'))
+      .mockRejectedValueOnce(new Error('Job failed again'))
+      .mockResolvedValueOnce('Job succeeded');
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'exponential_backoff' };
+    const signal = new AbortController().signal;
+
+    const result = await retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal });
+
+    expect(result).toBe('Job succeeded');
+    expect(doJob).toHaveBeenCalledTimes(3);
+    expect(retryable.retries).toBe(2);
+
+    const delayMilliseconds = retryPlugin['getRetryDelay'](0, config);
+    expect(delayMilliseconds).toBe(1000); // 1 * 2^0 * 1000
+
+    const delayMilliseconds2 = retryPlugin['getRetryDelay'](1, config);
+    expect(delayMilliseconds2).toBe(2000); // 1 * 2^1 * 1000
+  }, 8000);
+
+  it('calculates correct delay for linear_backoff strategy', async () => {
+    const doJob = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Job failed'))
+      .mockRejectedValueOnce(new Error('Job failed again'))
+      .mockResolvedValueOnce('Job succeeded');
+    const shouldRetryFn = jest.fn().mockReturnValue(true);
+    const retryable = { retries: 0 };
+    const config = { retryCount: 3, retryDelaySeconds: 1, retryStrategy: 'linear_backoff' };
+    const signal = new AbortController().signal;
+
+    const result = await retryPlugin.retry({ doJob, shouldRetryFn, retryable, config, signal });
+
+    expect(result).toBe('Job succeeded');
+    expect(doJob).toHaveBeenCalledTimes(3);
+    expect(retryable.retries).toBe(2);
+
+    const delayMilliseconds = retryPlugin['getRetryDelay'](0, config);
+    expect(delayMilliseconds).toBe(0); // 1 * 1.5 * 0 * 1000
+
+    const delayMilliseconds2 = retryPlugin['getRetryDelay'](1, config);
+    expect(delayMilliseconds2).toBe(1500); // 1 * 1.5 * 1 * 1000
+  }, 6000);
+
+  it('returns correct retry configuration for a task', () => {
+    const task = {
+      taskDef: {
+        retryCount: 3,
+        retryDelaySeconds: 2,
+        retryStrategy: 'exponential_backoff',
+      },
+    } as Task;
+
+    const session = {
+      getParameter: jest.fn().mockReturnValue(undefined),
+    } as unknown as ExecutionSession;
+
+    const expectedConfig: RetryConfig = {
+      retryCount: 3,
+      retryDelaySeconds: 2,
+      retryStrategy: 'exponential_backoff',
+    };
+
+    const runner = new DefaultWorkflowRunner();
+    const config = runner['lookupRetryConfig'](task, session);
+
+    expect(config).toEqual(expectedConfig);
+  });
+
+  it('should lookup retry config from parent task', () => {
+    const childTask = { taskDef: { retryCount: undefined } } as Task;
+    const parentTask = { taskDef: { retryCount: 3 } } as Task;
+    const session = {
+      getParentTask: jest.fn((task) => (task === childTask ? parentTask : undefined)),
+    } as unknown as ExecutionSession;
+
+    const runner = new DefaultWorkflowRunner() as WorkflowRunner;
+    const retryConfig = runner['lookupRetryConfig'](childTask, session);
+
+    expect(retryConfig.retryCount).toBe(3);
+  });
+});

--- a/packages/plugin/tests/default-retry-plugin.test.ts
+++ b/packages/plugin/tests/default-retry-plugin.test.ts
@@ -1,6 +1,5 @@
 import DefaultRetryPlugin from '@src/default-retry-plugin';
-import { ExecutionSession, InterruptInvokeError, RetryConfig, Task, WorkflowRunner } from '@letrun/core';
-import DefaultWorkflowRunner from '@src/default-workflow-runner';
+import { InterruptInvokeError } from '@letrun/core';
 
 const jest = import.meta.jest;
 
@@ -152,42 +151,4 @@ describe('DefaultRetryPlugin', () => {
     const delayMilliseconds2 = retryPlugin['getRetryDelay'](1, config);
     expect(delayMilliseconds2).toBe(1500); // 1 * 1.5 * 1 * 1000
   }, 6000);
-
-  it('returns correct retry configuration for a task', () => {
-    const task = {
-      taskDef: {
-        retryCount: 3,
-        retryDelaySeconds: 2,
-        retryStrategy: 'exponential_backoff',
-      },
-    } as Task;
-
-    const session = {
-      getParameter: jest.fn().mockReturnValue(undefined),
-    } as unknown as ExecutionSession;
-
-    const expectedConfig: RetryConfig = {
-      retryCount: 3,
-      retryDelaySeconds: 2,
-      retryStrategy: 'exponential_backoff',
-    };
-
-    const runner = new DefaultWorkflowRunner();
-    const config = runner['lookupRetryConfig'](task, session);
-
-    expect(config).toEqual(expectedConfig);
-  });
-
-  it('should lookup retry config from parent task', () => {
-    const childTask = { taskDef: { retryCount: undefined } } as Task;
-    const parentTask = { taskDef: { retryCount: 3 } } as Task;
-    const session = {
-      getParentTask: jest.fn((task) => (task === childTask ? parentTask : undefined)),
-    } as unknown as ExecutionSession;
-
-    const runner = new DefaultWorkflowRunner() as WorkflowRunner;
-    const retryConfig = runner['lookupRetryConfig'](childTask, session);
-
-    expect(retryConfig.retryCount).toBe(3);
-  });
 });


### PR DESCRIPTION
Introduce three new options for the retry-ability:

- retryCount: Number of retries to attempt when a Task is marked as failure.
- retryStrategy: Mechanism for the retries (fixed or backoff)
- retryDelaySeconds: Time to wait before retries in seconds

The retry is handled by new `RetryPlugin`