### PR TITLE
Task output type

### DIFF
--- a/docs/plugin/task-invoker.md
+++ b/docs/plugin/task-invoker.md
@@ -20,7 +20,7 @@ Here is an example of a Task Invoker Plugin:
 
 ```typescript
 import { AbstractPlugin, TASK_INVOKER_PLUGIN, TaskInvoker } from '@letrun/core';
-import { TaskHandlerInput, TaskHandlerOutput, InvalidParameterError } from '@letrun/common';
+import { TaskHandlerInput, InvalidParameterError } from '@letrun/common';
 import path from 'node:path';
 import fs from 'fs';
 
@@ -28,7 +28,7 @@ export default class CustomTaskInvoker extends AbstractPlugin implements TaskInv
   readonly name = 'custom';
   readonly type = TASK_INVOKER_PLUGIN;
 
-  async invoke(input: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async invoke(input: TaskHandlerInput) {
     const {
       task,
       session: { systemTasks },

--- a/docs/task/task-handler.md
+++ b/docs/task/task-handler.md
@@ -51,10 +51,11 @@ You can write custom tasks either in a simple JS file or a node package:
 
 A task handler should have the following structure:
 
-- `name`: The name of the task, this is optional. We'll use the file name or package name as the task name if not defined.
+- `name`: The name of the task, we'll use the file name or package name as the task name if not defined. This is optional.
 - `description`: A brief description of the task, this is optional.
-- `version`: The version of the task, this is optional. We'll use the package version if not defined.
-- `parameters`: An object that describes the input parameters of the task for showing help. (calls `Schema.describe()` from Joi)
+- `version`: The version of the task, we'll use the package version if not defined. This is optional.
+- `parameters`: An object that describes the input parameters of the task for showing help, set null if the task doesn't have parameters. This is optional.
+- `output`: An object that describes the output of the task for showing help, set null if the task doesn't have output. This is optional.
 - `handle`: The function that executes the task. This is required.
 
 There are alternative ways to define those fields by using these corresponding decorators:
@@ -62,7 +63,8 @@ There are alternative ways to define those fields by using these corresponding d
 - `@Name`: The name of the task.
 - `@Description`: A brief description of the task.
 - `@Version`: The version of the task.
-- `@Parameters`: An object that describes the input parameters of the task for showing help.
+- `@Parameters`: An object that describes the input parameters of the task for showing help. No value or null means the task doesn't have parameters.
+- `@Output`: An object that describes the output of the task for showing help. No value or null means the task doesn't have output.
 
 > _Vanilla JS_ does not support decorators yet, so you need to use Babel or TypeScript to work with them.
 
@@ -83,6 +85,7 @@ const Schema = Joi.object<TaskParameters>({
 
 @Name('greeting')
 @Parameters(Schema)
+@Output(Joi.string().description('The greeting message'))
 export default class GreetingTaskHandler implements TaskHandler {
   async handle({ task }: TaskHandlerInput) {
     const { message } = validateParameters(task.parameters, Schema);
@@ -110,6 +113,7 @@ const Schema = Joi.object<TaskParameters>({
 
 @Name('uppercase')
 @Parameters(Schema)
+@Output(Joi.string().description('The uppercase string'))
 export default class UppercaseTaskHandler implements TaskHandler {
   async handle({ task }: TaskHandlerInput) {
     const { value } = validateParameters(task.parameters, Schema);

--- a/packages/common/src/model/task-handler.ts
+++ b/packages/common/src/model/task-handler.ts
@@ -30,8 +30,14 @@ export interface TaskHandler<T = any> {
   description?: string;
   /**
    *  An object that describes the input parameters of the task for showing help.
+   *  If the task does not require any input, set this to null.
    */
-  parameters?: Joi.Description;
+  parameters?: Joi.Description | null;
+  /**
+   * An object that describes the output of the task for showing help.
+   * If the task does not return anything, set this to null.
+   */
+  output?: Joi.Description | null;
 
   /**
    * Handles the task.

--- a/packages/common/src/model/task-handler.ts
+++ b/packages/common/src/model/task-handler.ts
@@ -21,7 +21,7 @@ export interface TaskHandlerInput {
  * Interface representing a task handler.
  * Keeps the logic stateless because it will be recalled multiple times with different task data.
  */
-export interface TaskHandler {
+export interface TaskHandler<T = any> {
   /** The name of the task handler. */
   name?: string;
   /** The version of the task handler. */
@@ -38,12 +38,9 @@ export interface TaskHandler {
    * @param input - The input for the task handler.
    * @returns A promise that resolves to the output of the task handler.
    */
-  handle(input: TaskHandlerInput): Promise<TaskHandlerOutput> | TaskHandlerOutput;
+  handle(input: TaskHandlerInput): Promise<T> | T;
 }
 
 export interface TaskHandlerConstructor {
   new (): TaskHandler;
 }
-
-/** Type representing the output of a task handler. */
-export type TaskHandlerOutput = any;

--- a/packages/core/src/decorator/task-handler.ts
+++ b/packages/core/src/decorator/task-handler.ts
@@ -52,7 +52,7 @@ export function Description(value: string) {
 
 /**
  * A decorator that injects the parameters field to a {@link TaskHandler}. See {@link TaskHandler.parameters}.
- * @param value - task handler parameters.
+ * @param value - task handler parameters. If value is not provided, the parameters field will be set to null (no parameters are required).
  * @constructor
  *
  * @example
@@ -64,8 +64,28 @@ export function Description(value: string) {
  * }
  * ```
  */
-export function Parameters(value: Joi.Description | Joi.Schema) {
-  return injectFieldDecorator('parameters', isJoiSchema(value) ? value.describe() : value);
+export function Parameters(value?: Joi.Description | Joi.Schema | null) {
+  const effectiveValue = !value ? null : isJoiSchema(value) ? value.describe() : value;
+  return injectFieldDecorator('parameters', effectiveValue);
+}
+
+/**
+ * A decorator that injects the output field to a {@link TaskHandler}. See {@link TaskHandler.output}.
+ * @param value - task handler output. If value is not provided, the output field will be set to null (no output).
+ * @constructor
+ *
+ * @example
+ * ```ts
+ * @Output(Joi.object({
+ *   value: Joi.string().required(),
+ * }))
+ * class MyTaskHandler implements TaskHandler {
+ * }
+ * ```
+ */
+export function Output(value?: Joi.Description | Joi.Schema | null) {
+  const effectiveValue = !value ? null : isJoiSchema(value) ? value.describe() : value;
+  return injectFieldDecorator('output', effectiveValue);
 }
 
 function isJoiSchema(value: Joi.Description | Joi.Schema): value is Joi.Schema {

--- a/packages/core/src/plugin/task-invoker.ts
+++ b/packages/core/src/plugin/task-invoker.ts
@@ -1,9 +1,9 @@
-import { Plugin, TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { Plugin, TaskHandlerInput } from '@letrun/common';
 
 export const TASK_INVOKER_PLUGIN = 'task-invoker';
 
 export interface TaskInvoker extends Plugin {
   readonly type: typeof TASK_INVOKER_PLUGIN;
 
-  invoke(input: TaskHandlerInput): Promise<TaskHandlerOutput>;
+  invoke<T = any>(input: TaskHandlerInput): Promise<T>;
 }

--- a/packages/core/tests/decorator/task-handler.test.ts
+++ b/packages/core/tests/decorator/task-handler.test.ts
@@ -1,4 +1,4 @@
-import { Description, Name, Parameters, Version } from '@src/decorator/task-handler';
+import { Description, Name, Output, Parameters, Version } from '@src/decorator/task-handler';
 import Joi from 'joi';
 
 describe('TaskHandler Decorators', () => {
@@ -38,6 +38,14 @@ describe('TaskHandler Decorators', () => {
     expect((instance as any).parameters).toEqual(schema.describe());
   });
 
+  it('should inject null parameters field into TaskHandler', () => {
+    @Parameters(null)
+    class MyTaskHandler {}
+
+    const instance = new MyTaskHandler();
+    expect((instance as any).parameters).toBeNull();
+  });
+
   it('should inject parameters field with Joi description into TaskHandler', () => {
     const schema = Joi.object({
       name: Joi.string().required(),
@@ -48,6 +56,38 @@ describe('TaskHandler Decorators', () => {
 
     const instance = new MyTaskHandler();
     expect((instance as any).parameters).toEqual(schema.describe());
+  });
+
+  it('should inject output field into TaskHandler', () => {
+    const schema = Joi.object({
+      result: Joi.string().required(),
+    });
+
+    @Output(schema)
+    class MyTaskHandler {}
+
+    const instance = new MyTaskHandler();
+    expect((instance as any).output).toEqual(schema.describe());
+  });
+
+  it('should inject null output field into TaskHandler', () => {
+    @Output(null)
+    class MyTaskHandler {}
+
+    const instance = new MyTaskHandler();
+    expect((instance as any).output).toBeNull();
+  });
+
+  it('should inject output field with Joi description into TaskHandler', () => {
+    const schema = Joi.object({
+      name: Joi.string().required(),
+    });
+
+    @Output(schema.describe())
+    class MyTaskHandler {}
+
+    const instance = new MyTaskHandler();
+    expect((instance as any).output).toEqual(schema.describe());
   });
 
   it('should keep prototype methods after applying decorators', () => {
@@ -61,6 +101,7 @@ describe('TaskHandler Decorators', () => {
     @Version('1.0.0')
     @Description('This is a task handler')
     @Parameters(Joi.object({ name: Joi.string().required() }))
+    @Output(Joi.object({ value: Joi.string().required() }))
     class MyTaskHandler extends BaseClass {}
 
     const instance = new MyTaskHandler();
@@ -71,11 +112,15 @@ describe('TaskHandler Decorators', () => {
     const schema = Joi.object({
       name: Joi.string().required(),
     });
+    const outputSchema = Joi.object({
+      value: Joi.string().required(),
+    });
 
     @Name('my-task-handler')
     @Version('1.0.0')
     @Description('This is a task handler')
     @Parameters(schema)
+    @Output(outputSchema)
     class MyTaskHandler {}
 
     const instance = new MyTaskHandler();
@@ -83,5 +128,6 @@ describe('TaskHandler Decorators', () => {
     expect((instance as any).version).toBe('1.0.0');
     expect((instance as any).description).toBe('This is a task handler');
     expect((instance as any).parameters).toEqual(schema.describe());
+    expect((instance as any).output).toEqual(outputSchema.describe());
   });
 });

--- a/packages/engine/src/system-task/delay.ts
+++ b/packages/engine/src/system-task/delay.ts
@@ -1,4 +1,4 @@
-import { delayMs, Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { delayMs, Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import ms from 'ms';
@@ -15,9 +15,12 @@ const Schema = Joi.object<TaskParameters>({
   data: Joi.any().description('The data to pass to the output on time out'),
 });
 
+const OutputSchema = Joi.any().description('The "data" field from the input parameters');
+
 @Name('delay')
 @Description('Delays the execution of the workflow for a specified amount of time')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class DelayTaskHandler implements TaskHandler {
   async handle({ task, context, session }: TaskHandlerInput) {
     const { time, data } = validateParameters(task.parameters, Schema);

--- a/packages/engine/src/system-task/delay.ts
+++ b/packages/engine/src/system-task/delay.ts
@@ -1,5 +1,5 @@
 import { delayMs, Description, Name, Parameters, validateParameters } from '@letrun/core';
-import { TaskHandler, TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import ms from 'ms';
 
@@ -19,7 +19,7 @@ const Schema = Joi.object<TaskParameters>({
 @Description('Delays the execution of the workflow for a specified amount of time')
 @Parameters(Schema)
 export class DelayTaskHandler implements TaskHandler {
-  async handle({ task, context, session }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, context, session }: TaskHandlerInput) {
     const { time, data } = validateParameters(task.parameters, Schema);
     const delayMillis = typeof time === 'string' ? ms(time) : time;
     context.getLogger().verbose(`Delaying execution for ${delayMillis} milliseconds`);

--- a/packages/engine/src/system-task/for.ts
+++ b/packages/engine/src/system-task/for.ts
@@ -1,11 +1,8 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { RerunError, TaskDef, TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import { initNewIteration, validateLoopTask } from './loop-task';
 
-/**
- * Interface representing the parameters for the ForTaskHandler.
- */
 interface TaskParameters {
   /**
    * The starting value of the iterator.
@@ -27,9 +24,6 @@ interface TaskParameters {
   step?: number;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   from: Joi.number().description('The iterator will loop from this value').required(),
   to: Joi.number().description('The iterator will loop until reach this value').required(),
@@ -38,20 +32,19 @@ const Schema = Joi.object<TaskParameters>({
     .default(1),
 });
 
-/**
- * Class representing the handler for the 'for' task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.object({
+  index: Joi.number().description('The current index of the loop, starting from the "from" value'),
+  iteration: Joi.number().description('The current iteration of the loop, starting from 0'),
+  from: Joi.number().description('The starting value of the loop'),
+  to: Joi.number().description('The ending value of the loop'),
+  step: Joi.number().description('The step value of the loop'),
+});
+
 @Name('for')
 @Description('Loops through a specified range and performs tasks')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class ForTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<any>} The output of the task.
-   * @throws {RerunError} To notify the engine to rerun the task for another iteration.
-   */
   async handle({ task, context, session }: TaskHandlerInput): Promise<any> {
     const { from, to, step } = validateParameters(task.parameters, Schema);
 

--- a/packages/engine/src/system-task/http.ts
+++ b/packages/engine/src/system-task/http.ts
@@ -1,5 +1,5 @@
 import { Description, Name, Parameters, validateParameters } from '@letrun/core';
-import { TaskHandler, TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 
 /**
@@ -85,10 +85,9 @@ export class HttpTaskHandler implements TaskHandler {
   /**
    * Handles the task execution.
    * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<TaskHandlerOutput>} The output of the task.
    * @throws {Error} If the HTTP request fails.
    */
-  async handle({ task, session }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, session }: TaskHandlerInput) {
     const value = validateParameters(task.parameters, Schema);
     const url = new URL(value.url);
     if (value.params) {

--- a/packages/engine/src/system-task/http.ts
+++ b/packages/engine/src/system-task/http.ts
@@ -1,10 +1,7 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 
-/**
- * Interface representing the parameters for the HttpTaskHandler.
- */
 interface TaskParameters {
   /**
    * The URL endpoint to send the request.
@@ -50,9 +47,6 @@ interface TaskParameters {
   responseType?: 'json' | 'text' | 'blob';
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   url: Joi.string().description('The URL endpoint to send request').uri().required(),
   method: Joi.string()
@@ -74,19 +68,13 @@ const Schema = Joi.object<TaskParameters>({
     .default('json'),
 });
 
-/**
- * Class representing the handler for the HTTP task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.any().description('The response data from the HTTP request which depends on the responseType');
+
 @Name('http')
 @Description('Sends HTTP requests and processes responses')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class HttpTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @throws {Error} If the HTTP request fails.
-   */
   async handle({ task, session }: TaskHandlerInput) {
     const value = validateParameters(task.parameters, Schema);
     const url = new URL(value.url);

--- a/packages/engine/src/system-task/if.ts
+++ b/packages/engine/src/system-task/if.ts
@@ -1,10 +1,15 @@
-import { countTasks, Description, isWorkflowTaskDefsEmpty, Name, Parameters, validateParameters } from '@letrun/core';
+import {
+  countTasks,
+  Description,
+  isWorkflowTaskDefsEmpty,
+  Name,
+  Output,
+  Parameters,
+  validateParameters,
+} from '@letrun/core';
 import { InvalidParameterError, TaskDef, TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 
-/**
- * Interface representing the parameters for the IfTaskHandler.
- */
 interface TaskParameters {
   /**
    * The left operand of the expression.
@@ -42,9 +47,6 @@ interface TaskParameters {
   right: any;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   left: Joi.any().required(),
   operator: Joi.string()
@@ -75,19 +77,13 @@ const Schema = Joi.object<TaskParameters>({
   right: Joi.any(),
 });
 
-/**
- * Class representing the handler for the 'if' task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.boolean().description('The result of the expression');
+
 @Name('if')
 @Description('Executes tasks based on conditions')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class IfTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<boolean>} The output of the task.
-   */
   async handle({ task, context, session }: TaskHandlerInput): Promise<boolean> {
     const value = validateParameters(task.parameters, Schema);
     const matched = this.isMatched(value);

--- a/packages/engine/src/system-task/iterate.ts
+++ b/packages/engine/src/system-task/iterate.ts
@@ -1,4 +1,4 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { RerunError, TaskDef, TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import { initNewIteration, validateLoopTask } from './loop-task';
@@ -19,9 +19,15 @@ const Schema = Joi.object<TaskParameters>({
     }),
 });
 
+const OutputSchema = Joi.object({
+  iteration: Joi.number().description('The current iteration of the loop, starting from 0'),
+  item: Joi.any().description('The current item in the iteration'),
+});
+
 @Name('iterate')
 @Description('Loops through a list of items and performs tasks')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class IterateTaskHandler implements TaskHandler {
   async handle({ task, context, session }: TaskHandlerInput): Promise<any> {
     const { items } = validateParameters(task.parameters, Schema);

--- a/packages/engine/src/system-task/lambda.ts
+++ b/packages/engine/src/system-task/lambda.ts
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import {
   Description,
   Name,
+  Output,
   Parameters,
   SCRIPT_ENGINE_PLUGIN,
   ScriptEngine,
@@ -28,9 +29,12 @@ const Schema = Joi.object<TaskParameters>({
   .xor('expression', 'file')
   .required();
 
+const OutputSchema = Joi.any().description('The result of the lambda expression.');
+
 @Name('lambda')
 @Description('Evaluates a lambda expression.')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class LambdaTaskHandler implements TaskHandler {
   async handle(taskInput: TaskHandlerInput) {
     const { task, context, session } = taskInput;

--- a/packages/engine/src/system-task/log.ts
+++ b/packages/engine/src/system-task/log.ts
@@ -1,10 +1,7 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 
-/**
- * Interface representing the parameters for the LogTaskHandler.
- */
 interface TaskParameters {
   /**
    * The log level for the message.
@@ -19,26 +16,16 @@ interface TaskParameters {
   message: string;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   level: Joi.string().default('info').valid('debug', 'info', 'warn', 'error'),
   message: Joi.string().required(),
 });
 
-/**
- * Class representing the handler for the log task.
- * Implements the TaskHandler interface.
- */
 @Name('log')
 @Description('Outputs messages or errors for debugging')
 @Parameters(Schema)
+@Output()
 export class LogTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   */
   handle({ task, context }: TaskHandlerInput) {
     const { level, message } = validateParameters(task.parameters, Schema);
     context.getLogger()[level](message);

--- a/packages/engine/src/system-task/run-workflow.ts
+++ b/packages/engine/src/system-task/run-workflow.ts
@@ -1,12 +1,8 @@
-import { Description, Name, Parameters, validateParameters, wrapPromiseWithAbort } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters, wrapPromiseWithAbort } from '@letrun/core';
 import { RunnerOptions, TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import fs from 'fs';
 
-/**
- * Interface representing the parameters for the RunWorkflowTaskHandler.
- * Extends RunnerOptions.
- */
 interface TaskParameters extends RunnerOptions {
   /**
    * The input to pass to the workflow.
@@ -15,9 +11,6 @@ interface TaskParameters extends RunnerOptions {
   input?: any;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   file: Joi.string().description('The file path to the workflow to run'),
   workflow: Joi.any().description(
@@ -26,20 +19,13 @@ const Schema = Joi.object<TaskParameters>({
   input: Joi.any().description('The input to pass to the workflow'),
 }).xor('file', 'workflow');
 
-/**
- * Class representing the handler for the 'run-workflow' task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.any().description('The output of the sub-workflow');
+
 @Name('run-workflow')
 @Description('Runs another workflow within the current workflow')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class RunWorkflowTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<any>} The output of the task.
-   * @throws {Error} If the workflow fails to run or completes with an error.
-   */
   async handle({ task, session, context }: TaskHandlerInput): Promise<any> {
     const { workflow, input, file } = validateParameters(task.parameters, Schema);
     let workflowToRun = workflow ? (typeof workflow === 'string' ? JSON.parse(workflow) : workflow) : undefined;

--- a/packages/engine/src/system-task/switch.ts
+++ b/packages/engine/src/system-task/switch.ts
@@ -3,6 +3,7 @@ import {
   Description,
   isWorkflowTaskDefsEmpty,
   Name,
+  Output,
   Parameters,
   SCRIPT_ENGINE_PLUGIN,
   ScriptEngine,
@@ -12,9 +13,6 @@ import { IllegalStateError, InvalidParameterError, TaskDef, TaskHandler, TaskHan
 import Joi from 'joi';
 import { ScriptEngineWrapper } from '@src/libs/script-engine-wrapper';
 
-/**
- * Interface representing the parameters for the SwitchTaskHandler.
- */
 interface TaskParameters {
   /**
    * The expression to evaluate.
@@ -29,9 +27,6 @@ interface TaskParameters {
   language?: string;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   expression: Joi.string().description('The result of this expression will be matched with the target case').required(),
   language: Joi.string().description(
@@ -39,20 +34,13 @@ const Schema = Joi.object<TaskParameters>({
   ),
 });
 
-/**
- * Class representing the handler for the switch task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.string().description('The target case to switch to');
+
 @Name('switch')
 @Description('Chooses tasks based on input values')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class SwitchTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<string>} The target case.
-   * @throws {IllegalStateError} If no matching case or default case is found.
-   */
   async handle(input: TaskHandlerInput): Promise<string> {
     const { task, context, session } = input;
     const targetCase = await this.evaluateDecisionCase(input);
@@ -74,13 +62,6 @@ export class SwitchTaskHandler implements TaskHandler {
     return targetCase;
   }
 
-  /**
-   * Evaluates the decision case based on the task parameters.
-   * @private
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<string>} The evaluated decision case.
-   * @throws {InvalidParameterError} If the evaluator type is invalid.
-   */
   private async evaluateDecisionCase({ task, context, workflow }: TaskHandlerInput): Promise<string> {
     const { expression, language } = validateParameters(task.parameters, Schema);
     if (!language) {

--- a/packages/engine/src/system-task/while.ts
+++ b/packages/engine/src/system-task/while.ts
@@ -1,12 +1,17 @@
-import { Description, Name, Parameters, SCRIPT_ENGINE_PLUGIN, ScriptEngine, validateParameters } from '@letrun/core';
+import {
+  Description,
+  Name,
+  Output,
+  Parameters,
+  SCRIPT_ENGINE_PLUGIN,
+  ScriptEngine,
+  validateParameters,
+} from '@letrun/core';
 import { RerunError, TaskDef, TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import { initNewIteration, validateLoopTask } from './loop-task';
 import { ScriptEngineWrapper } from '@src/libs/script-engine-wrapper';
 
-/**
- * Interface representing the parameters for the WhileTaskHandler.
- */
 interface TaskParameters {
   /**
    * The JavaScript expression to evaluate.
@@ -27,9 +32,6 @@ interface TaskParameters {
   language?: string;
 }
 
-/**
- * Schema for validating the task parameters.
- */
 const Schema = Joi.object<TaskParameters>({
   expression: Joi.string().description('The javascript expression to evaluate').required(),
   mode: Joi.string()
@@ -39,20 +41,15 @@ const Schema = Joi.object<TaskParameters>({
   language: Joi.string().description('The language of the expression').default('javascript'),
 });
 
-/**
- * Class representing the handler for the 'while' task.
- * Implements the TaskHandler interface.
- */
+const OutputSchema = Joi.object({
+  iteration: Joi.number().description('The current iteration of the loop, starting from 0'),
+});
+
 @Name('while')
 @Description('Loops through tasks until a condition is met')
 @Parameters(Schema)
+@Output(OutputSchema)
 export class WhileTaskHandler implements TaskHandler {
-  /**
-   * Handles the task execution.
-   * @param {TaskHandlerInput} input - The input for the task handler.
-   * @returns {Promise<any>} The output of the task.
-   * @throws {RerunError} To notify the engine to rerun the task for another iteration.
-   */
   async handle({ task, workflow, context, session }: TaskHandlerInput): Promise<any> {
     const { expression, mode, language } = validateParameters(task.parameters, Schema);
 

--- a/packages/engine/tests/system-task/delay.test.ts
+++ b/packages/engine/tests/system-task/delay.test.ts
@@ -1,4 +1,4 @@
-import { TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { TaskHandlerInput } from '@letrun/common';
 import ms from 'ms';
 import { DelayTaskHandler } from '@src/system-task/delay';
 
@@ -43,7 +43,7 @@ describe('DelayTaskHandler', () => {
       session: mockSession,
     } as any;
 
-    const result: TaskHandlerOutput = await delayTaskHandler.handle(taskInput);
+    const result = await delayTaskHandler.handle(taskInput);
     expect(result).toBe('testData');
   });
 

--- a/packages/plugin/src/default-task-invoker.ts
+++ b/packages/plugin/src/default-task-invoker.ts
@@ -17,7 +17,6 @@ import {
   TaskGroup,
   TaskHandler,
   TaskHandlerInput,
-  TaskHandlerOutput,
   UNCATEGORIZED_TASK_GROUP,
 } from '@letrun/common';
 
@@ -35,7 +34,7 @@ export default class DefaultTaskInvoker extends AbstractPlugin implements TaskIn
     super();
   }
 
-  async invoke(input: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async invoke<T = any>(input: TaskHandlerInput): Promise<T> {
     const {
       task,
       session: { systemTasks },

--- a/packages/task/src/exec.ts
+++ b/packages/task/src/exec.ts
@@ -1,4 +1,4 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import { spawn } from 'child_process';
@@ -18,9 +18,12 @@ const Schema = Joi.object<TaskParameters>({
     .min(0),
 });
 
+const OutputSchema = Joi.any().description('The output of the command');
+
 @Name('exec')
 @Description('Executes a command in a new process')
 @Parameters(Schema)
+@Output(OutputSchema)
 export default class Handler implements TaskHandler {
   async handle({ task, context }: TaskHandlerInput) {
     const value = validateParameters(task.parameters, Schema);

--- a/packages/task/src/expect.ts
+++ b/packages/task/src/expect.ts
@@ -1,4 +1,4 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import { expect } from 'expect';
@@ -58,9 +58,12 @@ const Schema = Joi.object<TaskParameters>({
   message: Joi.string().description('The message to throw when the test fails'),
 });
 
+const OutputSchema = Joi.boolean().description('The result of the test');
+
 @Name('expect')
 @Description('Tests the object against the expected value')
 @Parameters(Schema)
+@Output(OutputSchema)
 export default class Handler implements TaskHandler {
   async handle({ task, context }: TaskHandlerInput) {
     const value = validateParameters(task.parameters, Schema);

--- a/packages/task/src/read-file.ts
+++ b/packages/task/src/read-file.ts
@@ -1,4 +1,4 @@
-import { Description, Name, Parameters, validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import * as fs from 'node:fs';
@@ -16,9 +16,12 @@ const Schema = Joi.object<TaskParameters>({
     .valid('json', 'text', 'line'),
 });
 
+const OutputSchema = Joi.any().description('The content of the file depending on the contentType');
+
 @Name('read-file')
 @Description('Reads the content of a file')
 @Parameters(Schema)
+@Output(OutputSchema)
 export default class Handler implements TaskHandler {
   async handle({ task, context }: TaskHandlerInput) {
     const { contentType, path } = validateParameters(task.parameters, Schema);

--- a/packages/task/src/read-file.ts
+++ b/packages/task/src/read-file.ts
@@ -1,5 +1,5 @@
 import { Description, Name, Parameters, validateParameters } from '@letrun/core';
-import { TaskHandler, TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import * as fs from 'node:fs';
 
@@ -20,7 +20,7 @@ const Schema = Joi.object<TaskParameters>({
 @Description('Reads the content of a file')
 @Parameters(Schema)
 export default class Handler implements TaskHandler {
-  async handle({ task, context }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, context }: TaskHandlerInput) {
     const { contentType, path } = validateParameters(task.parameters, Schema);
     context.getLogger().debug(`Reading from file: ${path}`);
     const content = await fs.promises.readFile(path, 'utf8');

--- a/packages/task/src/write-file.ts
+++ b/packages/task/src/write-file.ts
@@ -1,4 +1,4 @@
-import { validateParameters } from '@letrun/core';
+import { Description, Name, Output, Parameters, validateParameters } from '@letrun/core';
 import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import * as fs from 'node:fs';
@@ -15,6 +15,10 @@ const Schema = Joi.object<TaskParameters>({
   append: Joi.boolean().description('Append to the file instead of overwriting').default(false),
 });
 
+@Name('write-file')
+@Description('Writes content to a file')
+@Parameters(Schema)
+@Output()
 export default class Handler implements TaskHandler {
   name = 'write-file';
   parameters = Schema.describe();

--- a/packages/task/src/write-file.ts
+++ b/packages/task/src/write-file.ts
@@ -1,5 +1,5 @@
 import { validateParameters } from '@letrun/core';
-import { TaskHandler, TaskHandlerInput, TaskHandlerOutput } from '@letrun/common';
+import { TaskHandler, TaskHandlerInput } from '@letrun/common';
 import Joi from 'joi';
 import * as fs from 'node:fs';
 
@@ -19,7 +19,7 @@ export default class Handler implements TaskHandler {
   name = 'write-file';
   parameters = Schema.describe();
 
-  async handle({ task, context }: TaskHandlerInput): Promise<TaskHandlerOutput> {
+  async handle({ task, context }: TaskHandlerInput) {
     const { append, path, content } = validateParameters(task.parameters, Schema);
     const textContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
     context.getLogger().debug(`Writing to file: ${path}`);


### PR DESCRIPTION
Introduce a new `output` field and `@Output` decorator to describe the task output. The ~TaskHandlerOutput~ is replaced by a generic type `T`