### PR TITLE
Task metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ letrun [command] [options]
   - [run](docs/command/task-run): Run a task directly without a workflow.
   - [install](docs/command/task-install): Install a custom task package.
   - [versions](docs/command/task-versions): List all installed custom task packages.
+  - [meta](docs/command/task-meta): Extract the metadata of a task.
 
 ## Plugin
 

--- a/docs/command/task-meta.md
+++ b/docs/command/task-meta.md
@@ -1,0 +1,88 @@
+# `meta` Task Command
+
+The `meta` task command is used to extract metadata from a task.
+
+## Usage
+
+```sh
+letrun task meta [name] [options]
+```
+
+### Arguments
+
+- `[name]`: The name of the task to extract metadata from. If not provided, metadata will be extracted from system tasks.
+
+### Options
+
+- `-p, --pipe`: Pipe the metadata to the standard output.
+- `-o, --output <output>`: Write the metadata to a file.
+
+### Examples
+
+#### Extract metadata from a script task
+
+```sh
+letrun task meta myscript.js
+```
+
+#### Extract metadata from a system task
+
+```sh
+letrun task meta log
+```
+
+The output will be similar to the following:
+
+```json
+{
+  "name": "System",
+  "description": "Built-in tasks",
+  "tasks": [
+    {
+      "name": "log",
+      "description": "Outputs messages or errors for debugging",
+      "parameters": {
+        "type": "object",
+        "keys": {
+          "level": {
+            "type": "string",
+            "flags": {
+              "default": "info",
+              "only": true
+            },
+            "allow": [
+              "debug",
+              "info",
+              "warn",
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "flags": {
+              "presence": "required"
+            }
+          }
+        }
+      },
+      "output": null
+    }
+  ]
+}
+```
+
+#### Extract metadata from a task package
+
+```sh
+let run task meta @letrun-task/file
+```
+
+> The CLI will install the task package if it is not already installed.
+
+#### Pipe metadata to the standard output
+
+```sh
+letrun task meta myscript.js -p > meta.json
+```
+
+> The metadata will be written to `meta.json` file.

--- a/docs/plugin/metadata-extractor.md
+++ b/docs/plugin/metadata-extractor.md
@@ -1,0 +1,49 @@
+# Metadata Extractor Plugin
+
+The `Metadata Extractor Plugin` is used to extract metadata from either a task handler string or a task group or a parsed handler.
+These extracted metadata can be used to generate documentation or to provide additional information about the task handler or task group.
+
+> The metadata is always a [TaskGroupMetadata](../../packages/common/src/model/task-group.ts) object.
+
+## Usage
+
+To use the `Metadata Extractor Plugin`, you need to implement the `MetadataExtractorPlugin` interface and register the plugin with the CLI tool.
+
+### Example
+
+Here is an example of a Metadata Extractor Plugin:
+
+```typescript
+import { AbstractPlugin, METADATA_EXTRACTOR, MetadataExtractor } from '@letrun/core';
+import { Command } from 'commander';
+import art from './art';
+import { ParsedHandler, TaskGroup, TaskGroupMetadata, TaskHandler } from '@letrun/common';
+import is from '@sindresorhus/is';
+import undefined = is.undefined;
+
+export default class ExampleExtractMetadata extends AbstractPlugin implements MetadataExtractor {
+  readonly name = 'example';
+  readonly type = METADATA_EXTRACTOR;
+
+  async extract(parsedHandler: ParsedHandler | TaskGroup | TaskHandler): Promise<TaskGroupMetadata> {
+    return {
+      name: 'Example Metadata',
+      description: 'This is an example metadata',
+      tasks: [],
+    };
+  }
+}
+```
+
+### Registering the Plugin
+
+To register the Metadata Extractor Plugin, place it in the `plugins` directory (or the directory specified in your configuration) and ensure it is loaded by the CLI tool.
+
+### Output
+
+This example above will always return the same metadata for any task handler or task group.
+
+## Summary
+
+This plugin is used internally by the CLI tool to extract metadata from task handlers and task groups.
+You can implement your own Metadata Extractor Plugin to add more additional metadata to the task handlers or task groups or do whatever you want with the metadata.

--- a/docs/plugin/plugin.md
+++ b/docs/plugin/plugin.md
@@ -86,3 +86,4 @@ Here are supported plugin types:
 11. [Pre/Post Run Workflow Plugin](pre-post-run-workflow-plugin.md)
 12. [Pre/Post Run Task Plugin](pre-post-run-task-plugin.md)
 13. [Task Handler Location Resolver](task-handler-location-resolver)
+14. [Metadata Extractor](metadata-extractor.md)

--- a/packages/cli/src/command/task/index.ts
+++ b/packages/cli/src/command/task/index.ts
@@ -5,6 +5,7 @@ import { ViewCommand } from './view.command';
 import { RunCommand } from './run.command';
 import { InstallCommand } from './install.command';
 import { VersionsCommand } from './versions.command';
+import { MetaCommand } from './meta.command';
 
 export class TaskCommand extends AbstractCommand {
   load(program: Command): void {
@@ -14,5 +15,6 @@ export class TaskCommand extends AbstractCommand {
     new RunCommand(this.context).load(command);
     new InstallCommand(this.context).load(command);
     new VersionsCommand(this.context).load(command);
+    new MetaCommand(this.context).load(command);
   }
 }

--- a/packages/cli/src/command/task/meta.command.ts
+++ b/packages/cli/src/command/task/meta.command.ts
@@ -1,0 +1,122 @@
+import { NpmPackage } from '@letrun/deps';
+import { AbstractCommand, AbstractOptions } from '../abstract.command';
+import { Command } from 'commander';
+import ora from 'ora';
+import { ParsedHandler, SYSTEM_TASK_GROUP, TaskHandler } from '@letrun/common';
+import {
+  defaultTaskHandlerParser,
+  METADATA_EXTRACTOR,
+  MetadataExtractor,
+  TASK_HANDLER_LOCATION_RESOLVER_PLUGIN,
+  TaskHandlerLocationResolver,
+} from '@letrun/core';
+import fs from 'fs';
+import { SystemTaskManager } from '@letrun/engine';
+import { LogHelper } from '../libs/log-helper';
+
+export class MetaCommand extends AbstractCommand {
+  private npmPackage = new NpmPackage();
+
+  load(program: Command): void {
+    program
+      .command('meta')
+      .description('extract metadata from a task')
+      .argument('[name]', 'package name <name>@<version>')
+      .option('-p, --pipe', 'Pipe the output to the next command', false)
+      .option('-o, --output <output>', 'Output file which contains the metadata')
+      .action(async (name, options) => {
+        if (options.pipe) {
+          await LogHelper.usePipeMode(this.context, async () => {
+            return await this.doAction(name, options);
+          });
+        } else {
+          await this.doAction(name, options);
+        }
+      });
+  }
+
+  private async doAction(name?: string, options?: AbstractOptions) {
+    const doExtract = async () => {
+      const extractor = await this.context.getPluginManager().getOne<MetadataExtractor>(METADATA_EXTRACTOR);
+      const systemTasks = SystemTaskManager.getSystemTasks() ?? {};
+
+      if (!name) {
+        return await extractor.extract({
+          ...SYSTEM_TASK_GROUP,
+          tasks: systemTasks,
+        });
+      }
+
+      if (systemTasks[name]) {
+        return await this.extractSystemTask(systemTasks[name]!, extractor);
+      } else if (fs.existsSync(name)) {
+        return await this.extractFromPath(name, extractor);
+      }
+      return await this.extractFromPackage(name, extractor);
+    };
+
+    const metadata = await doExtract();
+    if (options?.output) {
+      await fs.promises.writeFile(options.output, JSON.stringify(metadata, null, 2), 'utf8');
+    }
+    return metadata;
+  }
+
+  private async extractSystemTask(taskHandler: TaskHandler, extractor: MetadataExtractor) {
+    return await extractor.extract({
+      ...SYSTEM_TASK_GROUP,
+      tasks: {
+        [taskHandler.name!]: taskHandler,
+      },
+    });
+  }
+
+  private async extractFromPath(path: string, extractor: MetadataExtractor) {
+    const stat = await fs.promises.stat(path);
+    const parsedHandler: ParsedHandler = {
+      name: path,
+      type: stat.isDirectory() ? 'external' : 'script',
+    };
+    return await extractor.extract(parsedHandler);
+  }
+
+  private async extractFromPackage(name: string, extractor: MetadataExtractor) {
+    const parsedHandler = defaultTaskHandlerParser.parse(name);
+
+    const location = await this.context!.getPluginManager().callPluginMethod<TaskHandlerLocationResolver, string>(
+      TASK_HANDLER_LOCATION_RESOLVER_PLUGIN,
+      'resolveLocation',
+      parsedHandler,
+      false,
+    );
+
+    if (!location) {
+      if (parsedHandler.type !== 'package') {
+        throw new Error(`Cannot find module: ${name}`);
+      }
+
+      const effectivePackageName = parsedHandler.version
+        ? `${parsedHandler.name}@${parsedHandler.version}`
+        : parsedHandler.name;
+      const installed = await this.installPackage(effectivePackageName);
+
+      if (!installed) {
+        throw new Error(`Cannot find module: ${name}`);
+      }
+    }
+
+    return await extractor.extract(parsedHandler);
+  }
+
+  private async installPackage(name: string) {
+    const spinner = ora(`Package ${name} was not found, installing...`).start();
+    try {
+      await this.npmPackage.install(name);
+      spinner.succeed(`Package ${name} installed`);
+      return true;
+    } catch (e: any) {
+      spinner.fail(e.message);
+      return false;
+    }
+  }
+}

--- a/packages/cli/tests/command/task/meta.command.test.ts
+++ b/packages/cli/tests/command/task/meta.command.test.ts
@@ -1,0 +1,126 @@
+import { Command } from 'commander';
+import { SystemTaskManager } from '@letrun/engine';
+import fs from 'fs';
+import { MetaCommand } from '@src/command/task/meta.command';
+import { defaultTaskHandlerParser } from '@letrun/core';
+import { SYSTEM_TASK_GROUP } from '@letrun/common';
+
+const jest = import.meta.jest;
+
+describe('MetaCommand', () => {
+  let metaCommand: MetaCommand;
+  let program: Command;
+  let context: any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    context = { getPluginManager: jest.fn() };
+    metaCommand = new MetaCommand(context);
+    program = new Command();
+  });
+
+  it('loads the meta command', () => {
+    metaCommand.load(program);
+    expect(program.commands[0]?.name()).toBe('meta');
+  });
+
+  it('extracts metadata from a system task', async () => {
+    const mockTaskHandler = { name: 'mockTask', handle: () => {} };
+    const mockGetSystemTasks = jest
+      .spyOn(SystemTaskManager, 'getSystemTasks')
+      .mockReturnValue({ mockTask: mockTaskHandler });
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    context.getPluginManager.mockReturnValue({ getOne: jest.fn().mockResolvedValue(mockExtractor) });
+
+    const result = await (metaCommand as any).doAction('mockTask');
+    expect(result).toBe('metadata');
+    mockGetSystemTasks.mockReset();
+  });
+
+  it('extracts metadata from a file path', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'stat').mockResolvedValue({ isDirectory: jest.fn().mockReturnValue(true) } as any);
+
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    context.getPluginManager.mockReturnValue({ getOne: jest.fn().mockResolvedValue(mockExtractor) });
+
+    const result = await (metaCommand as any).doAction('mockPath');
+    expect(result).toBe('metadata');
+  });
+
+  it('extracts metadata from a package', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    const mockParsedHandler = { name: 'mockPackage', type: 'package' };
+    const mockPluginManager = {
+      getOne: jest.fn().mockResolvedValue(mockExtractor),
+      callPluginMethod: jest.fn().mockResolvedValue('mockLocation'),
+    };
+    context.getPluginManager.mockReturnValue(mockPluginManager);
+    jest.spyOn(defaultTaskHandlerParser, 'parse').mockReturnValue(mockParsedHandler as any);
+
+    const result = await (metaCommand as any).doAction('mockPackage');
+    expect(result).toBe('metadata');
+  });
+
+  it('installs package if not found', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    const mockParsedHandler = { name: 'mockPackage', type: 'package' };
+    const mockPluginManager = {
+      getOne: jest.fn().mockResolvedValue(mockExtractor),
+      callPluginMethod: jest.fn().mockResolvedValue(null),
+    };
+    context.getPluginManager.mockReturnValue(mockPluginManager);
+    jest.spyOn(defaultTaskHandlerParser, 'parse').mockReturnValue(mockParsedHandler as any);
+    jest.spyOn(metaCommand as any, 'installPackage').mockResolvedValue(true);
+
+    const result = await (metaCommand as any).doAction('mockPackage');
+    expect(result).toBe('metadata');
+  });
+
+  it('throws error if package cannot be found or installed', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    const mockParsedHandler = { name: 'mockPackage', type: 'package' };
+    const mockPluginManager = {
+      getOne: jest.fn().mockResolvedValue(mockExtractor),
+      callPluginMethod: jest.fn().mockResolvedValue(null),
+    };
+    context.getPluginManager.mockReturnValue(mockPluginManager);
+    jest.spyOn(defaultTaskHandlerParser, 'parse').mockReturnValue(mockParsedHandler as any);
+    jest.spyOn(metaCommand as any, 'installPackage').mockResolvedValue(false);
+
+    await expect((metaCommand as any).doAction('mockPackage')).rejects.toThrow('Cannot find module: mockPackage');
+  });
+
+  it('writes metadata to output file if output option is provided', async () => {
+    const mockMetadata = { key: 'value' };
+    const mockExtractor = { extract: jest.fn().mockResolvedValue(mockMetadata) };
+    const mockWriteFile = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+    const mockPluginManager = {
+      getOne: jest.fn().mockResolvedValue(mockExtractor),
+      callPluginMethod: jest.fn().mockResolvedValue('mockLocation'),
+    };
+    context.getPluginManager.mockReturnValue(mockPluginManager);
+
+    await (metaCommand as any).doAction('mockTask', { output: 'output.json' });
+
+    expect(mockWriteFile).toHaveBeenCalledWith('output.json', JSON.stringify(mockMetadata, null, 2), 'utf8');
+  });
+
+  it('extracts metadata for all system tasks when name is not provided', async () => {
+    const mockSystemTasks = { task1: { name: 'task1' }, task2: { name: 'task2' } } as any;
+    const mockExtractor = { extract: jest.fn().mockResolvedValue('metadata') };
+    jest.spyOn(SystemTaskManager, 'getSystemTasks').mockReturnValue(mockSystemTasks);
+    context.getPluginManager.mockReturnValue({ getOne: jest.fn().mockResolvedValue(mockExtractor) });
+
+    const result = await (metaCommand as any).doAction();
+
+    expect(result).toBe('metadata');
+    expect(mockExtractor.extract).toHaveBeenCalledWith({
+      ...SYSTEM_TASK_GROUP,
+      tasks: mockSystemTasks,
+    });
+  });
+});

--- a/packages/common/src/model/task-group.ts
+++ b/packages/common/src/model/task-group.ts
@@ -1,4 +1,4 @@
-import { TaskHandler } from './task-handler';
+import { TaskHandler, TaskMetadata } from './task-handler';
 
 /**
  * The default task group that contains tasks that have not been assigned to a group.
@@ -47,4 +47,16 @@ export interface TaskGroup {
    * - `script`: A task group that is defined in a standalone script file.
    */
   type?: 'package' | 'script';
+}
+
+/**
+ * Metadata for describing a task group.
+ */
+export interface TaskGroupMetadata {
+  name: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  type?: 'package' | 'script';
+  tasks: TaskMetadata[];
 }

--- a/packages/common/src/model/task-handler.ts
+++ b/packages/common/src/model/task-handler.ts
@@ -50,3 +50,14 @@ export interface TaskHandler<T = any> {
 export interface TaskHandlerConstructor {
   new (): TaskHandler;
 }
+
+/**
+ * Metadata for describing a task.
+ */
+export interface TaskMetadata {
+  name: string;
+  version?: string;
+  description?: string;
+  parameters?: Joi.Description | null;
+  output?: Joi.Description | null;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "@tsconfig/node20": "^20.1.2",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.5",
+    "@types/validate-npm-package-name": "^4.0.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.2",
@@ -57,6 +58,7 @@
     "@letrun/common": "^0.0.2",
     "commander": "^12.1.0",
     "compare-versions": "^6.1.1",
+    "validate-npm-package-name": "^5.0.1",
     "joi": "^17.13.3",
     "rxjs": "^7.8.1"
   }

--- a/packages/core/src/libs/task-handler-parser.ts
+++ b/packages/core/src/libs/task-handler-parser.ts
@@ -1,4 +1,6 @@
-import { ParsedHandler } from '@letrun/common';
+import { HandlerType, ParsedHandler } from '@letrun/common';
+import validate from 'validate-npm-package-name';
+import { extractJsExtension } from '../utils';
 
 export type TaskHandlerParserFn = (rawHandler: string) => ParsedHandler;
 
@@ -14,7 +16,7 @@ export class TaskHandlerParser {
 
     if (!match) {
       return {
-        type: 'script',
+        type: this.guessType(input),
         name: input,
       };
     }
@@ -28,6 +30,11 @@ export class TaskHandlerParser {
       ...(taskName && { taskName }),
     };
   };
+
+  private guessType(input: string): HandlerType {
+    const isValidNpmPackage = validate(input).validForNewPackages;
+    return isValidNpmPackage ? 'package' : extractJsExtension(input) ? 'script' : 'external';
+  }
 }
 
 export const defaultTaskHandlerParser = new TaskHandlerParser();

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -12,3 +12,4 @@ export * from './abstract-plugin';
 export * from './common';
 export * from './retry-plugin';
 export * from './task-handler-location-resolver';
+export * from './metadata-extractor';

--- a/packages/core/src/plugin/metadata-extractor.ts
+++ b/packages/core/src/plugin/metadata-extractor.ts
@@ -1,0 +1,14 @@
+import { ParsedHandler, Plugin, TaskGroup, TaskGroupMetadata, TaskHandler } from '@letrun/common';
+
+export const METADATA_EXTRACTOR = 'metadata-extractor';
+
+/**
+ * Extracts task group metadata from either a task handler or a task group or a parsed handler.
+ */
+export interface MetadataExtractor extends Plugin {
+  readonly type: typeof METADATA_EXTRACTOR;
+
+  extract(parsedHandler: ParsedHandler): Promise<TaskGroupMetadata>;
+  extract(taskGroup: TaskGroup): Promise<TaskGroupMetadata>;
+  extract(task: TaskHandler): Promise<TaskGroupMetadata>;
+}

--- a/packages/core/tests/libs/module-resolver.test.ts
+++ b/packages/core/tests/libs/module-resolver.test.ts
@@ -159,41 +159,4 @@ describe('ModuleResolver', () => {
       await expect(moduleResolver.resolve(modulePath)).rejects.toThrow('package.json not found in /absolute/path/module');
     });
   });
-
-  describe('resolve from node_modules', () => {
-    it('resolves a module from node_modules', async () => {
-      const modulePath = '/absolute/path/node_modules/module';
-      jest.spyOn(moduleResolver as any, 'isFile').mockReturnValue(false);
-      jest.spyOn(moduleResolver as any, 'isInsideNodeModules').mockReturnValue(true);
-      jest.spyOn(moduleResolver as any, 'getModuleNameFromNodeModulesPath').mockReturnValue('module');
-      jest.spyOn(moduleResolver as any, 'dynamicImport').mockResolvedValue({ default: 'resolvedModule' });
-      jest.spyOn(moduleResolver as any, 'getModuleType').mockResolvedValue('module');
-
-      const result = await moduleResolver.resolve(modulePath);
-      expect(result).toEqual({ default: 'resolvedModule' });
-    });
-
-    it('resolves a module from node_modules with commonjs type', async () => {
-      const modulePath = '/absolute/path/node_modules/module';
-      jest.spyOn(moduleResolver as any, 'isFile').mockReturnValue(false);
-      jest.spyOn(moduleResolver as any, 'isInsideNodeModules').mockReturnValue(true);
-      jest.spyOn(moduleResolver as any, 'getModuleNameFromNodeModulesPath').mockReturnValue('module');
-      jest.spyOn(moduleResolver as any, 'dynamicImport').mockResolvedValue({ default: { default: 'resolvedModule' } });
-      jest.spyOn(moduleResolver as any, 'getModuleType').mockResolvedValue('commonjs');
-
-      const result = await moduleResolver.resolve(modulePath);
-      expect(result).toEqual({ default: 'resolvedModule' });
-    });
-
-    it('throws an error when module type is invalid', async () => {
-      const modulePath = '/absolute/path/node_modules/module';
-      jest.spyOn(moduleResolver as any, 'isFile').mockReturnValue(false);
-      jest.spyOn(moduleResolver as any, 'isInsideNodeModules').mockReturnValue(true);
-      jest.spyOn(moduleResolver as any, 'getModuleNameFromNodeModulesPath').mockReturnValue('module');
-      jest.spyOn(moduleResolver as any, 'dynamicImport').mockResolvedValue({ default: 'resolvedModule' });
-      jest.spyOn(moduleResolver as any, 'getModuleType').mockResolvedValue('invalid');
-
-      await expect(moduleResolver.resolve(modulePath)).rejects.toThrow();
-    });
-  });
 });

--- a/packages/core/tests/libs/task-handler-parser.test.ts
+++ b/packages/core/tests/libs/task-handler-parser.test.ts
@@ -1,6 +1,8 @@
 import { ParsedHandler } from '@letrun/common';
 import { TaskHandlerParser } from '@src/libs';
 
+const jest = import.meta.jest;
+
 describe('TaskHandlerParser', () => {
   const parser = new TaskHandlerParser();
 
@@ -31,15 +33,6 @@ describe('TaskHandlerParser', () => {
     expect(result).toEqual(expected);
   });
 
-  it('returns a script handler when input has an invalid type', () => {
-    const rawHandler = 'invalidtype:handler-name';
-    const expected: ParsedHandler = { type: 'script', name: 'invalidtype:handler-name' };
-
-    const result = parser.parse(rawHandler);
-
-    expect(result).toEqual(expected);
-  });
-
   it('parses a handler with type package, name, and version', () => {
     const rawHandler = 'package:handler-name@1.0.0';
     const expected: ParsedHandler = { type: 'package', name: 'handler-name', version: '1.0.0' };
@@ -52,15 +45,6 @@ describe('TaskHandlerParser', () => {
   it('parses a handler with type package, name, version, and task name', () => {
     const rawHandler = 'package:handler-name@1.0.0:task-name';
     const expected: ParsedHandler = { type: 'package', name: 'handler-name', version: '1.0.0', taskName: 'task-name' };
-
-    const result = parser.parse(rawHandler);
-
-    expect(result).toEqual(expected);
-  });
-
-  it('returns a script handler when input does not match the expected pattern', () => {
-    const rawHandler = 'invalid-handler-format';
-    const expected: ParsedHandler = { type: 'script', name: 'invalid-handler-format' };
 
     const result = parser.parse(rawHandler);
 
@@ -225,5 +209,17 @@ describe('TaskHandlerParser', () => {
     const result = parser.parse(rawHandler);
 
     expect(result).toEqual(expected);
+  });
+
+  it('guesses type when input does not match pattern', () => {
+    const rawHandler = 'invalid-handler';
+    const expected: ParsedHandler = { type: 'external', name: 'invalid-handler' };
+
+    jest.spyOn(parser as any, 'guessType').mockReturnValue('external');
+
+    const result = parser.parse(rawHandler);
+
+    expect(result).toEqual(expected);
+    expect((parser as any).guessType).toHaveBeenCalledWith(rawHandler);
   });
 });

--- a/packages/deps/src/workflow-deps-scanner.ts
+++ b/packages/deps/src/workflow-deps-scanner.ts
@@ -51,7 +51,7 @@ export class WorkflowDepsScanner {
 
     dependencies = this.removeDuplicatedPackages(dependencies);
     const candidatePackages = dependencies.filter(
-      (dep) => dep.type === 'package' && !dep.installed && !validate(dep.handler?.name!).errors?.length,
+      (dep) => dep.type === 'package' && !dep.installed && validate(dep.handler?.name!).validForNewPackages,
     );
 
     if (candidatePackages.length) {

--- a/packages/plugin/src/default-metadata-extractor.ts
+++ b/packages/plugin/src/default-metadata-extractor.ts
@@ -1,0 +1,90 @@
+import {
+  AbstractPlugin,
+  defaultTaskGroupResolver,
+  METADATA_EXTRACTOR,
+  MetadataExtractor,
+  TASK_HANDLER_LOCATION_RESOLVER_PLUGIN,
+  TaskHandlerLocationResolver,
+} from '@letrun/core';
+import {
+  InvalidParameterError,
+  ParsedHandler,
+  TaskGroup,
+  TaskGroupMetadata,
+  TaskHandler,
+  UNCATEGORIZED_TASK_GROUP,
+} from '@letrun/common';
+
+export default class DefaultMetadataExtractor extends AbstractPlugin implements MetadataExtractor {
+  readonly name = 'default';
+  readonly type = METADATA_EXTRACTOR;
+
+  async extract(input: ParsedHandler | TaskGroup | TaskHandler): Promise<TaskGroupMetadata> {
+    let taskGroup: TaskGroup | undefined;
+    if (this.isParsedHandler(input)) {
+      const location = await this.context!.getPluginManager().callPluginMethod<TaskHandlerLocationResolver, string>(
+        TASK_HANDLER_LOCATION_RESOLVER_PLUGIN,
+        'resolveLocation',
+        input,
+        true,
+      );
+
+      if (!location) {
+        throw new InvalidParameterError(`Cannot find module: ${input.name}`);
+      }
+
+      taskGroup = await defaultTaskGroupResolver.resolve(location);
+    } else if (this.isTaskHandler(input)) {
+      if (!input.name) {
+        throw new InvalidParameterError('Task handler name is required');
+      }
+
+      taskGroup = {
+        ...UNCATEGORIZED_TASK_GROUP,
+        version: input.version,
+        description: input.description,
+        type: 'script',
+        tasks: {
+          [input.name]: input,
+        },
+      };
+    } else if (this.isTaskGroup(input)) {
+      taskGroup = input;
+    }
+
+    if (!taskGroup) {
+      throw new InvalidParameterError('Invalid input');
+    }
+
+    return this.extractFromTaskGroup(taskGroup);
+  }
+
+  private extractFromTaskGroup(taskGroup: TaskGroup): TaskGroupMetadata {
+    return {
+      name: taskGroup.name,
+      version: taskGroup.version,
+      description: taskGroup.description,
+      author: taskGroup.author,
+      type: taskGroup.type,
+      tasks: Object.entries(taskGroup.tasks ?? {}).map(([name, handler]) => ({
+        name: handler.name ?? name,
+        version: handler.version,
+        description: handler.description,
+        parameters: handler.parameters,
+        output: handler.output,
+      })),
+    };
+  }
+
+  private isParsedHandler(input: ParsedHandler | TaskGroup | TaskHandler): input is ParsedHandler {
+    return !this.isTaskHandler(input) && !this.isTaskGroup(input);
+  }
+
+  private isTaskHandler(input: ParsedHandler | TaskGroup | TaskHandler): input is TaskHandler {
+    return typeof (input as TaskHandler).handle === 'function';
+  }
+
+  private isTaskGroup(input: ParsedHandler | TaskGroup | TaskHandler): input is TaskGroup {
+    return typeof (input as TaskGroup).tasks === 'object';
+  }
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -11,6 +11,7 @@ import JavascriptEngine from './javascript-engine';
 import PythonEngine from './python-engine';
 import DefaultRetryPlugin from './default-retry-plugin';
 import DefaultTaskHandlerLocationResolver from './default-task-handler-location-resolver';
+import DefaultMetadataExtractor from './default-metadata-extractor';
 
 export class DefaultPluginLoader implements PluginLoader {
   async load() {
@@ -27,6 +28,7 @@ export class DefaultPluginLoader implements PluginLoader {
       new PythonEngine(),
       new DefaultRetryPlugin(),
       new DefaultTaskHandlerLocationResolver(),
+      new DefaultMetadataExtractor(),
     ];
   }
 }

--- a/packages/plugin/tests/default-metadata-extractor.test.ts
+++ b/packages/plugin/tests/default-metadata-extractor.test.ts
@@ -1,0 +1,251 @@
+import {
+  InvalidParameterError,
+  PluginManager,
+  TaskGroup,
+  TaskGroupMetadata,
+  TaskHandler,
+  UNCATEGORIZED_TASK_GROUP,
+} from '@letrun/common';
+import DefaultMetadataExtractor from '@src/default-metadata-extractor';
+import { defaultTaskGroupResolver } from '@letrun/core';
+
+const jest = import.meta.jest;
+
+describe('DefaultMetadataExtractor', () => {
+  let extractor: DefaultMetadataExtractor;
+  let pluginManager: jest.Mocked<PluginManager>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    extractor = new DefaultMetadataExtractor();
+    pluginManager = {
+      callPluginMethod: jest.fn(),
+    } as any;
+    (extractor as any).context = { getPluginManager: () => pluginManager };
+  });
+
+  it('extracts metadata successfully', async () => {
+    const parsedHandler = { name: 'testHandler' };
+    const taskGroupMetadata: TaskGroupMetadata = {
+      name: 'testGroup',
+      version: '1.0.0',
+      description: 'A test task group',
+      author: 'Author',
+      type: 'script',
+      tasks: [],
+    };
+
+    pluginManager.callPluginMethod.mockResolvedValue('test/location');
+    jest.spyOn(defaultTaskGroupResolver, 'resolve').mockResolvedValue({
+      ...taskGroupMetadata,
+      tasks: {},
+    });
+
+    const result = await extractor.extract(parsedHandler as any);
+
+    expect(result).toEqual(taskGroupMetadata);
+  });
+
+  it('throws InvalidParameterError when location is not found', async () => {
+    const parsedHandler = { name: 'testHandler' } as any;
+
+    pluginManager.callPluginMethod.mockResolvedValue(null);
+
+    await expect(extractor.extract(parsedHandler)).rejects.toThrow(InvalidParameterError);
+  });
+
+  it('throws error when task group resolution fails', async () => {
+    const parsedHandler = { name: 'testHandler' } as any;
+
+    pluginManager.callPluginMethod.mockResolvedValue('test/location');
+    jest.spyOn(defaultTaskGroupResolver, 'resolve').mockRejectedValue(new Error('Resolution failed'));
+
+    await expect(extractor.extract(parsedHandler)).rejects.toThrow('Resolution failed');
+  });
+
+  it('resolves tasks correctly', async () => {
+    const parsedHandler = { name: 'testHandler' };
+    const taskGroupMetadata: TaskGroupMetadata = {
+      name: 'testGroup',
+      version: '1.0.0',
+      description: 'A test task group',
+      author: 'Author',
+      type: 'script',
+      tasks: [
+        {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+          parameters: {},
+          output: {},
+        },
+        {
+          name: 'task2',
+          version: '1.0.0',
+          description: 'Second task',
+          parameters: {},
+          output: {},
+        },
+      ],
+    };
+
+    pluginManager.callPluginMethod.mockResolvedValue('test/location');
+    jest.spyOn(defaultTaskGroupResolver, 'resolve').mockResolvedValue({
+      ...taskGroupMetadata,
+      tasks: {
+        task1: {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+          parameters: {},
+          output: {},
+        },
+        task2: {
+          name: 'task2',
+          version: '1.0.0',
+          description: 'Second task',
+          parameters: {},
+          output: {},
+        },
+      } as any,
+    });
+
+    const result = await extractor.extract(parsedHandler as any);
+
+    expect(result.tasks).toEqual([
+      {
+        name: 'task1',
+        version: '1.0.0',
+        description: 'First task',
+        parameters: {},
+        output: {},
+      },
+      {
+        name: 'task2',
+        version: '1.0.0',
+        description: 'Second task',
+        parameters: {},
+        output: {},
+      },
+    ]);
+  });
+
+  it('resolves tasks with missing fields', async () => {
+    const parsedHandler = { name: 'testHandler' };
+    const taskGroupMetadata: TaskGroupMetadata = {
+      name: 'testGroup',
+      version: '1.0.0',
+      description: 'A test task group',
+      author: 'Author',
+      type: 'script',
+      tasks: [
+        {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+        },
+      ],
+    };
+
+    pluginManager.callPluginMethod.mockResolvedValue('test/location');
+    jest.spyOn(defaultTaskGroupResolver, 'resolve').mockResolvedValue({
+      ...taskGroupMetadata,
+      tasks: {
+        task1: {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+        },
+      } as any,
+    });
+
+    const result = await extractor.extract(parsedHandler as any);
+
+    expect(result.tasks).toEqual([
+      {
+        name: 'task1',
+        version: '1.0.0',
+        description: 'First task',
+        parameters: undefined,
+        output: undefined,
+      },
+    ]);
+  });
+
+  it('extracts metadata from TaskGroup successfully', async () => {
+    const taskGroup: TaskGroup = {
+      name: 'testGroup',
+      version: '1.0.0',
+      description: 'A test task group',
+      author: 'Author',
+      type: 'script',
+      tasks: {
+        task1: {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+          parameters: {},
+          output: {},
+          handle: () => {},
+        },
+      },
+    };
+
+    const result = await extractor.extract(taskGroup);
+
+    expect(result).toEqual({
+      name: 'testGroup',
+      version: '1.0.0',
+      description: 'A test task group',
+      author: 'Author',
+      type: 'script',
+      tasks: [
+        {
+          name: 'task1',
+          version: '1.0.0',
+          description: 'First task',
+          parameters: {},
+          output: {},
+        },
+      ],
+    });
+  });
+
+  it('extracts metadata from TaskHandler successfully', async () => {
+    const taskHandler: TaskHandler = {
+      name: 'taskHandler',
+      version: '1.0.0',
+      description: 'A test task handler',
+      parameters: {},
+      output: {},
+      handle: jest.fn(),
+    };
+
+    const result = await extractor.extract(taskHandler);
+
+    expect(result).toEqual({
+      ...UNCATEGORIZED_TASK_GROUP,
+      version: '1.0.0',
+      description: 'A test task handler',
+      type: 'script',
+      tasks: [
+        {
+          name: 'taskHandler',
+          version: '1.0.0',
+          description: 'A test task handler',
+          parameters: {},
+          output: {},
+        },
+      ],
+    });
+  });
+
+  it('throws InvalidParameterError when TaskHandler has no name', async () => {
+    const taskHandler: TaskHandler = {
+      handle: jest.fn(),
+    };
+
+    await expect(extractor.extract(taskHandler)).rejects.toThrow(InvalidParameterError);
+  });
+});


### PR DESCRIPTION
Task metadata is the way to describe the task, this can be consumed by the `letrun-studio` so the studio can show what tasks are available, what input/output are supported, and so on.